### PR TITLE
Add `MonadPlus` and laws

### DIFF
--- a/lib/bags/agda/Haskell/Law/MonadPlus.agda
+++ b/lib/bags/agda/Haskell/Law/MonadPlus.agda
@@ -1,0 +1,5 @@
+module Haskell.Law.MonadPlus where
+
+open import Haskell.Law.MonadPlus.Def    public
+open import Haskell.Law.MonadPlus.List   public
+open import Haskell.Law.MonadPlus.Maybe  public

--- a/lib/bags/agda/Haskell/Law/MonadPlus/Def.agda
+++ b/lib/bags/agda/Haskell/Law/MonadPlus/Def.agda
@@ -1,0 +1,62 @@
+module Haskell.Law.MonadPlus.Def where
+
+open import Haskell.Prim
+
+open import Haskell.Prim.Alternative
+open import Haskell.Prim.Applicative
+open import Haskell.Prim.Functor
+open import Haskell.Prim.Monad
+open import Haskell.Prim.MonadPlus
+open import Haskell.Prim.Monoid
+open import Haskell.Prim.Tuple
+
+open import Haskell.Law.Equality
+open import Haskell.Law.Monad
+open import Haskell.Law.Monad.Extra
+open import Haskell.Law.Monoid
+
+--------------------------------------------------
+-- IsLawfulMonadPlus
+
+record IsLawfulMonadPlus (m : Type → Type) ⦃ i : MonadPlus m ⦄ : Type₁ where
+  field
+    overlap ⦃ super ⦄ : IsLawfulMonad m
+
+    mplus-mzero-x : ∀ (x : m a)     → mplus mzero x ≡ x
+    mplus-x-mzero : ∀ (x : m a)     → mplus x mzero ≡ x
+    mplus-assoc   : ∀ (x y z : m a) → mplus (mplus x y) z ≡ mplus x (mplus y z)
+
+    mzero-bind : ∀ (k  : a → m b) → mzero >>= k ≡ mzero
+    bind-mzero : ∀ (mx : m a)     → mx >>= (λ x → mzero) ≡ mzero {m} {b}
+
+open IsLawfulMonadPlus ⦃ ... ⦄ public
+
+-- convenient synonym
+prop-mzero->>=
+  : ∀ ⦃ _ : MonadPlus m ⦄ ⦃ _ : IsLawfulMonadPlus m ⦄
+  → (k : a → m b) → mzero >>= k ≡ mzero
+prop-mzero->>= = mzero-bind
+
+prop-mzero->>
+  : ∀ {a b} ⦃ _ : MonadPlus m ⦄ ⦃ _ : IsLawfulMonadPlus m ⦄
+  → (my : m b) → mzero {m} {a} >> my ≡ mzero
+prop-mzero->> {m} {a} my =
+  begin
+    (mzero {m} {a} >> my)
+  ≡⟨ prop->>->>= _ _ ⟩
+    (mzero {m} {a} >>= (λ x → my))
+  ≡⟨ prop-mzero->>= _ ⟩
+    mzero
+  ∎
+
+--------------------------------------------------
+-- IsDistributiveMonadPlus
+
+record IsDistributiveMonadPlus (m : Type → Type) ⦃ _ : MonadPlus m ⦄ : Type₁ where
+  field
+    overlap ⦃ super ⦄ : IsLawfulMonadPlus m
+
+    mplus-bind : ∀ {a b} (x y : m a) (k : a → m b)
+      →  mplus x y >>= k  ≡  mplus (x >>= k) (y >>= k)
+
+open IsDistributiveMonadPlus ⦃ ... ⦄ public

--- a/lib/bags/agda/Haskell/Law/MonadPlus/List.agda
+++ b/lib/bags/agda/Haskell/Law/MonadPlus/List.agda
@@ -1,0 +1,39 @@
+module Haskell.Law.MonadPlus.List where
+
+open import Haskell.Prim
+open import Haskell.Prim.List
+
+open import Haskell.Prim.Monad
+open import Haskell.Prim.MonadPlus
+
+open import Haskell.Law.MonadPlus.Def
+
+open import Haskell.Law.Equality
+open import Haskell.Law.List
+open import Haskell.Law.Monad.List
+
+--------------------------------------------------
+-- IsLawfulMonadPlus
+
+private
+  prop-bind-mzero : ∀ (xs : List a) → xs >>= (λ x → mzero) ≡ mzero {List} {b}
+  prop-bind-mzero [] = refl
+  prop-bind-mzero {a} {b} (x ∷ xs)
+    rewrite prop-bind-mzero {a} {b} xs
+    = refl
+
+instance
+  iLawfulMonadPlusList : IsLawfulMonadPlus List
+  iLawfulMonadPlusList .mplus-mzero-x = []-++
+  iLawfulMonadPlusList .mplus-x-mzero = ++-[]
+  iLawfulMonadPlusList .mplus-assoc = ++-assoc
+  iLawfulMonadPlusList .mzero-bind k = refl
+  iLawfulMonadPlusList .bind-mzero = prop-bind-mzero
+
+--------------------------------------------------
+-- IsDistributiveMonadPlus
+
+instance
+  iDistributiveMonadPlusList : IsDistributiveMonadPlus List
+  iDistributiveMonadPlusList .mplus-bind x y k =
+    sym (concatMap-++-distr x y k)

--- a/lib/bags/agda/Haskell/Law/MonadPlus/Maybe.agda
+++ b/lib/bags/agda/Haskell/Law/MonadPlus/Maybe.agda
@@ -1,0 +1,40 @@
+module Haskell.Law.MonadPlus.Maybe where
+
+open import Haskell.Prim
+open import Haskell.Prim.Eq
+open import Haskell.Prim.Maybe
+
+open import Haskell.Prim.Monad
+open import Haskell.Prim.MonadPlus
+
+open import Haskell.Law.MonadPlus.Def
+open import Haskell.Law.Monad.Maybe
+
+--------------------------------------------------
+-- IsLawfulMonadPlus
+
+instance
+  iLawfulMonadPlusMaybe : IsLawfulMonadPlus Maybe
+  iLawfulMonadPlusMaybe .mplus-mzero-x Nothing = refl
+  iLawfulMonadPlusMaybe .mplus-mzero-x (Just x) = refl
+
+  iLawfulMonadPlusMaybe .mplus-x-mzero Nothing = refl
+  iLawfulMonadPlusMaybe .mplus-x-mzero (Just x) = refl
+
+  iLawfulMonadPlusMaybe .mplus-assoc Nothing y z = refl
+  iLawfulMonadPlusMaybe .mplus-assoc (Just x) y z = refl
+
+  iLawfulMonadPlusMaybe .mzero-bind k = refl
+
+  iLawfulMonadPlusMaybe .bind-mzero Nothing  = refl
+  iLawfulMonadPlusMaybe .bind-mzero (Just x) = refl
+
+--------------------------------------------------
+-- IsDistributiveMonadPlus
+
+¬-IsDistributMonadPlusMaybe : IsDistributiveMonadPlus Maybe → ⊥
+¬-IsDistributMonadPlusMaybe (record {mplus-bind = mplus-bind}) =
+    case mplus-bind (Just 1) (Just 2) k of λ ()
+  where
+    k : Nat → Maybe Nat
+    k x = if x == 1 then Nothing else Just x

--- a/lib/bags/agda/Haskell/Prim/Alternative.agda
+++ b/lib/bags/agda/Haskell/Prim/Alternative.agda
@@ -1,0 +1,49 @@
+module Haskell.Prim.Alternative where
+
+open import Haskell.Prim
+open import Haskell.Prim.Applicative
+open import Haskell.Prim.IO
+open import Haskell.Prim.List
+open import Haskell.Prim.Maybe
+
+--------------------------------------------------
+-- Alternative class
+
+-- ** base
+record Alternative (f : Type → Type) : Type₁ where
+  field
+    empty : f a
+    _<|>_ : f a → f a → f a
+    overlap ⦃ super ⦄ : Applicative f
+
+    -- We do not define `some` and `many` yet,
+    -- because they yield infinite co-data!
+    -- some : f a → f (List a)
+    -- many : f a → f (List a)
+
+-- ** export
+open Alternative ⦃...⦄ public
+{-# COMPILE AGDA2HS Alternative existing-class #-}
+
+-- ** instances
+instance
+  iAlternativeList : Alternative List
+  iAlternativeList .empty = []
+  iAlternativeList ._<|>_ = _++_
+
+  iAlternativeMaybe : Alternative Maybe
+  iAlternativeMaybe .empty = Nothing
+  iAlternativeMaybe ._<|>_ Nothing  my = my
+  iAlternativeMaybe ._<|>_ (Just x) _  = Just x
+
+instance postulate iAlternativeIO : Alternative IO
+
+--------------------------------------------------
+-- Helper functions
+
+-- | Conditional failure of 'Alternative' computations.
+--
+-- Very useful in @do@ notation of a 'MonadPlus'.
+guard : ⦃ Alternative f ⦄ → Bool → f ⊤
+guard True  = pure tt
+guard False = empty

--- a/lib/bags/agda/Haskell/Prim/MonadPlus.agda
+++ b/lib/bags/agda/Haskell/Prim/MonadPlus.agda
@@ -1,0 +1,53 @@
+module Haskell.Prim.MonadPlus where
+
+open import Haskell.Prim
+open import Haskell.Prim.Alternative
+open import Haskell.Prim.IO
+open import Haskell.Prim.List
+open import Haskell.Prim.Maybe
+open import Haskell.Prim.Monad
+
+--------------------------------------------------
+-- MonadPlus
+
+-- ** base
+record MonadPlus (m : Type → Type) : Type₁ where
+  field
+    overlap ⦃ alternative ⦄ : Alternative m
+    overlap ⦃ monad ⦄ : Monad m
+
+    -- The 'Applicative' instances from the two superclasses are the same.
+    -- This is required for global uniqueness of type classes in Haskell.
+    unique-applicative : alternative .Alternative.super ≡ monad .Monad.super
+
+-- Note: To infer that member functions such as `pure` are equal, using
+-- `cong Applicative.pure unique-applicative`
+-- may not type check, as `cong` does not work with `Type₁`.
+-- Provide a different definition of `cong` to make this work.
+
+-- ** defaults
+--
+-- In order to simplify proofs, we impose the laws
+--   mzero ≡ empty
+--   mplus ≡ _<|>_
+-- by definition.
+
+mzero : ⦃ MonadPlus m ⦄ → m a
+mzero = empty
+
+mplus : ⦃ MonadPlus m ⦄ → m a → m a → m a
+mplus = _<|>_
+
+-- ** export
+open MonadPlus ⦃...⦄ public
+{-# COMPILE AGDA2HS MonadPlus existing-class #-}
+
+-- ** instances
+instance
+  iMonadPlusList : MonadPlus List
+  iMonadPlusList = record { unique-applicative = refl }
+
+  iMonadPlusMaybe : MonadPlus Maybe
+  iMonadPlusMaybe = record { unique-applicative = refl }
+
+instance postulate iMonadPlusIO : MonadPlus IO

--- a/lib/bags/agda/bags.agda
+++ b/lib/bags/agda/bags.agda
@@ -1,3 +1,11 @@
 -- This file imports all modules from the library.
 
+import Haskell.Prim.Monad.Extra
+import Haskell.Prim.Alternative
+import Haskell.Prim.MonadPlus
+
+import Haskell.Law.Extensionality
+import Haskell.Law.Monad.Extra
+import Haskell.Law.MonadPlus
+
 import Data.Bag


### PR DESCRIPTION
This pull requests adds the `Alternative` and `MonadPlus` type classes.

Importantly, we have to add a property that the implied `Applicative` superclasses for `MonadPlus` coming from `Monad` and `Alternative` agreed. This is automatic in Haskell, but needs to be enforced in Agda2hs.