### PR TITLE
Add `Monoid` concepts

### DIFF
--- a/lib/bags/agda/Data/Monoid/Morphism.agda
+++ b/lib/bags/agda/Data/Monoid/Morphism.agda
@@ -1,0 +1,40 @@
+-- | Monoid morphisms
+module Data.Monoid.Morphism where
+
+open import Haskell.Prim
+open import Haskell.Prim.Monoid
+
+open import Haskell.Law
+
+-------------------------------------------------------------------------------
+-- Monoid Homomorphisms
+
+record IsHomomorphism ⦃ _ : Monoid a ⦄ ⦃ _ : Monoid b ⦄ (f : a → b)
+    : Type where
+  constructor MkIsHomomorphism
+  field
+    homo-mempty : f mempty ≡ mempty
+    homo-<>     : ∀ x y → f (x <> y) ≡ f x <> f y
+
+open IsHomomorphism public
+
+-------------------------------------------------------------------------------
+-- Properties
+
+-- | The identity map is a homomorphism.
+prop-morphism-id : ∀ ⦃ _ : Monoid a ⦄ → IsHomomorphism (id {a})
+--
+prop-morphism-id = MkIsHomomorphism refl (λ x y → refl)
+
+-- | The composition of two homomorphisms is again a homomorphism.
+prop-morphism-∘
+  : ∀ ⦃ _ : Monoid a ⦄ ⦃ _ : Monoid b ⦄ ⦃ _ : Monoid c ⦄
+      (f : a → b) (g : b → c)
+  → IsHomomorphism f → IsHomomorphism g → IsHomomorphism (g ∘ f)
+--
+prop-morphism-∘ f g prop-f prop-g = record
+  { homo-mempty =
+    trans (cong g (homo-mempty prop-f)) (homo-mempty prop-g)
+  ; homo-<> = λ x y →
+    trans (cong g (homo-<> prop-f x y)) (homo-<> prop-g (f x) (f y))
+  }

--- a/lib/bags/agda/Data/Monoid/Refinement.agda
+++ b/lib/bags/agda/Data/Monoid/Refinement.agda
@@ -1,0 +1,79 @@
+{-# OPTIONS --erasure #-}
+
+-- | Monoids with additional properties.
+module Data.Monoid.Refinement where
+
+open import Haskell.Prim
+open import Haskell.Prim.Monoid
+open import Haskell.Prim.Num
+open import Haskell.Prim.Tuple
+
+open import Haskell.Law
+open import Haskell.Law.Extensionality
+open import Haskell.Law.Num
+
+-------------------------------------------------------------------------------
+-- Commutative monoids
+
+record Commutative (a : Type) : Type where
+  field
+    overlap ⦃ monoid ⦄ : Monoid a
+
+    @0 commutative : ∀ (x y : a) → x <> y ≡ y <> x
+
+open Commutative ⦃...⦄ public
+
+{-# COMPILE AGDA2HS Commutative class #-}
+
+-------------------------------------------------------------------------------
+-- Instances
+
+instance
+  iCommutativeFun : ⦃ Commutative b ⦄ → Commutative (a → b)
+  iCommutativeFun .monoid = iMonoidFun
+  iCommutativeFun .commutative f g = ext (λ x → commutative (f x) (g x))
+
+  iCommutativeUnit : Commutative ⊤
+  iCommutativeUnit .monoid = iMonoidUnit
+  iCommutativeUnit .commutative x y = refl
+
+  iCommutativeTuple₂
+    : ⦃ Commutative a ⦄ → ⦃ Commutative b ⦄ → Commutative (a × b)
+  iCommutativeTuple₂ .monoid = iMonoidTuple₂
+  iCommutativeTuple₂ .commutative (x1 , x2) (y1 , y2)
+    rewrite commutative x1 y1
+    rewrite commutative x2 y2
+    = refl
+
+  iCommutativeTuple₃
+    : ⦃ Commutative a ⦄ → ⦃ Commutative b ⦄ → ⦃ Commutative c ⦄
+    → Commutative (a × b × c)
+  iCommutativeTuple₃ .monoid = iMonoidTuple₃
+  iCommutativeTuple₃ .commutative (x1 , x2 , x3) (y1 , y2 , y3)
+    rewrite commutative x1 y1
+    rewrite commutative x2 y2
+    rewrite commutative x3 y3
+    = refl
+
+{-# COMPILE AGDA2HS iCommutativeUnit #-}
+{-# COMPILE AGDA2HS iCommutativeTuple₂ #-}
+{-# COMPILE AGDA2HS iCommutativeTuple₃ #-}
+
+CommutativeSum : ⦃ _ : Num a ⦄ → ⦃ IsLawfulNum a ⦄ → Commutative a
+CommutativeSum .monoid = MonoidSum
+CommutativeSum .commutative = +-comm
+
+CommutativeConj : Commutative Bool
+CommutativeConj .monoid = MonoidConj
+CommutativeConj .commutative = prop-&&-sym
+
+CommutativeDisj : Commutative Bool
+CommutativeDisj .monoid = MonoidDisj
+CommutativeDisj .commutative = prop-||-sym
+
+{- *-comm is not part of IsLawfulNum yet?!
+
+CommutativeProduct : ⦃ _ : Num a ⦄ → ⦃ _ : IsLawfulNum a ⦄ → Commutative a
+CommutativeProduct .monoid = MonoidProduct
+CommutativeProduct .commutative = *-comm
+-}

--- a/lib/bags/agda/bags.agda
+++ b/lib/bags/agda/bags.agda
@@ -8,4 +8,7 @@ import Haskell.Law.Extensionality
 import Haskell.Law.Monad.Extra
 import Haskell.Law.MonadPlus
 
+import Data.Monoid.Morphism
+import Data.Monoid.Refinement
+
 import Data.Bag


### PR DESCRIPTION
This pull request adds `Monoid` concepts, specifically

* `IsHomomorphism f` — indicates that the function `f : a → b` is a homomorphism of monoids.
* `Commutative` — a type class for monoids that are also commutative.