### PR TITLE
Axiomatize `Bag` data type as free commutative monoid

### DIFF
--- a/lib/bags/agda/Data/Bag.agda
+++ b/lib/bags/agda/Data/Bag.agda
@@ -1,47 +1,5 @@
+module Data.Bag where
 
-module Data.Bag
-  {-|
-  ; Bag
-  -} where
-
-open import Haskell.Prelude
-
-{-----------------------------------------------------------------------------
-    Bag
-------------------------------------------------------------------------------}
--- | A unordered, finite collection of items.
--- Items may appear more than once.
---
--- Bag is the free commutative monoid.
-record Bag (a : Type) : Type where
-  constructor MkBag
-  field
-    elements : List a
-
-open Bag public
-
-{-# COMPILE AGDA2HS Bag #-}
-
--- | Delete the first occurrence of an item from the list.
--- Return 'Nothing' if the element does not occur.
-delete1 : ⦃ Eq a ⦄ → a → List a → Maybe (List a)
-delete1 x [] = Nothing
-delete1 x (y ∷ ys) = if x == y then Just ys else fmap (y ∷_) (delete1 x ys)
-
-{-# COMPILE AGDA2HS delete1 #-}
-
--- | Two lists are equal as bags.
-eqBag : ⦃ Eq a ⦄ →  List a → List a → Bool
-eqBag []       []       = True
-eqBag []       (y ∷ ys) = False
-eqBag (x ∷ xs) ys'      = case delete1 x ys' of λ where
-    (Just ys) → eqBag xs ys
-    Nothing   → False
-
-{-# COMPILE AGDA2HS eqBag #-}
-
-instance
-  iEqBag : ⦃ Eq a ⦄ → Eq (Bag a)
-  iEqBag ._==_ (MkBag xs) (MkBag ys) = eqBag xs ys
-
-{-# COMPILE AGDA2HS iEqBag derive #-}
+open import Data.Bag.Def  public
+open import Data.Bag.Core public
+open import Data.Bag.Prop public

--- a/lib/bags/agda/Data/Bag/Core.agda
+++ b/lib/bags/agda/Data/Bag/Core.agda
@@ -1,0 +1,212 @@
+{-# OPTIONS --confluence-check #-}
+
+-- | Core axiomatization of 'Bag' as the free commutative monoid.
+module Data.Bag.Core where
+
+open import Agda.Builtin.Equality.Rewrite
+
+open import Haskell.Prim
+open import Haskell.Prim.Monoid
+open import Haskell.Law
+open import Haskell.Law.Extensionality using (ext)
+open import Haskell.Law.Function
+open import Haskell.Law.Monoid
+open import Haskell.Law.Monoid as Monoid
+
+import Data.Monoid.Refinement as Monoid
+import Data.Monoid.Morphism as Monoid
+
+{-----------------------------------------------------------------------------
+    Type Definition
+------------------------------------------------------------------------------}
+postulate
+  Bag : Type → Type
+
+  singleton : a → Bag a
+
+  -- Bags are a monoid.
+  instance
+    iMonoidBag : Monoid (Bag a)
+
+instance
+  iSemigroupBag : Semigroup (Bag a)
+  iSemigroupBag = iMonoidBag .Monoid.super
+
+postulate
+  instance
+    iLawfulMonoidBag : IsLawfulMonoid (Bag a)
+
+  -- Bags are a commutative monoid.
+  prop-<>-sym : Commutative (_<>_ {Bag a})
+
+  -- Universal property, existence:
+  -- Any map to a commutative monoid factors through 'Bag'
+  foldBag
+    : ∀ ⦃ _ : Monoid.Commutative b ⦄
+    → (a → b) → (Bag a → b)
+
+  prop-foldBag-singleton
+    : ∀ ⦃ _ : Monoid.Commutative b ⦄ (f : a → b) (x : a)
+    → foldBag f (singleton x) ≡ f x
+
+  prop-foldBag-mempty
+    : ∀ ⦃ _ : Monoid.Commutative b ⦄ (f : a → b)
+    → foldBag f mempty ≡ mempty
+
+  prop-foldBag-<>
+    : ∀ ⦃ _ : Monoid.Commutative b ⦄ (f : a → b) (xs ys : Bag a)
+    → foldBag f (xs <> ys) ≡ foldBag f xs <> foldBag f ys
+
+  -- Universal property, uniqueness
+  prop-foldBag-unique
+    : ∀ ⦃ _ : Monoid.Commutative b ⦄ (g : Bag a → b)
+    → @0 Monoid.IsHomomorphism g
+    → ∀ (xs : Bag a) → foldBag (g ∘ singleton) xs ≡ g xs
+
+instance
+  iLawfulSemigroupBag : IsLawfulSemigroup (Bag a)
+  iLawfulSemigroupBag = iLawfulMonoidBag .super
+
+  iMonoidCommutativeBag : Monoid.Commutative (Bag a)
+  iMonoidCommutativeBag .Monoid.monoid = iMonoidBag
+  iMonoidCommutativeBag .Monoid.commutative = prop-<>-sym
+
+{- [Rewrite foldBag]
+
+In order to make the 'Bag' quotient type easy to use,
+we introduce rewrite rules that allow us to compute 'foldBag'.
+-}
+{-# REWRITE prop-foldBag-singleton #-}
+{-# REWRITE prop-foldBag-mempty #-}
+{-# REWRITE prop-foldBag-<> #-}
+
+{-----------------------------------------------------------------------------
+    Core properties
+------------------------------------------------------------------------------}
+-- | 'foldBag' is a homomorphism of 'Monoid'.
+prop-morphism-foldBag
+  : ∀ ⦃ _ : Monoid.Commutative b ⦄ (f : a → b)
+  → Monoid.IsHomomorphism (foldBag f)
+--
+prop-morphism-foldBag f = Monoid.MkIsHomomorphism refl (λ x y → refl)
+
+-- | Proof principle:
+-- Two maps @f@, @g@ from 'Bag' to any commutative monoid are equal if:
+--
+-- * They are monoid homomorphisms.
+--   This property typically follows from composition of morphisms.
+-- * And they are equal on 'singleton'.
+--   With the rewrite rules, this property can be computed.
+prop-Bag-equality
+  : ∀ ⦃ _ : Monoid.Commutative b ⦄ (f g : Bag a → b)
+  → @0 Monoid.IsHomomorphism f → @0 Monoid.IsHomomorphism g
+  → (∀ x → f (singleton x) ≡ g (singleton x))
+  → ∀ xs → f xs ≡ g xs
+--
+prop-Bag-equality f g hom-f hom-g eq-singleton xs =
+  begin
+    f xs
+  ≡⟨ sym (prop-foldBag-unique f hom-f xs) ⟩
+    foldBag (f ∘ singleton) xs
+  ≡⟨ cong (λ o → foldBag o xs) (ext eq-singleton) ⟩
+    foldBag (g ∘ singleton) xs
+  ≡⟨ prop-foldBag-unique g hom-g xs ⟩
+    g xs
+  ∎
+
+-- | Proof principle for functions with two 'Bag' arguments.
+prop-Bag-equality-2
+  : ∀ ⦃ _ : Monoid.Commutative c ⦄ (f g : Bag a → Bag b → c)
+  → @0 (∀ xs → Monoid.IsHomomorphism (λ ys → f xs ys))
+  → @0 (∀ xs → Monoid.IsHomomorphism (λ ys → g xs ys))
+  → @0 (∀ ys → Monoid.IsHomomorphism (λ xs → f xs ys))
+  → @0 (∀ ys → Monoid.IsHomomorphism (λ xs → g xs ys))
+  → (∀ x y → f (singleton x) (singleton y) ≡ g (singleton x) (singleton y))
+  → ∀ xs ys → f xs ys ≡ g xs ys
+--
+prop-Bag-equality-2 f g hom-f1 hom-g1 hom-f2 hom-g2 eq-singleton =
+  λ xs → prop-Bag-equality _ _ (hom-f1 xs) (hom-g1 xs) (λ y → lemma y xs)
+  where
+    lemma : ∀ y xs → f xs (singleton y) ≡ g xs (singleton y)
+    lemma y = prop-Bag-equality _ _ (hom-f2 _) (hom-g2 _) (λ x → eq-singleton x y)
+
+{-----------------------------------------------------------------------------
+    Properties
+    Homomorphisms
+------------------------------------------------------------------------------}
+-- | 'foldBag' that maps to 'mempty' will return 'mempty'.
+prop-foldBag-function-mempty
+  : ∀ {a b} ⦃ iMb : Monoid.Commutative b ⦄ ⦃ _ : IsLawfulMonoid b ⦄
+      (xs : Bag a)
+  → foldBag (λ x → mempty) xs ≡ mempty
+--
+prop-foldBag-function-mempty {a} {b} {{iMb}} =
+    prop-foldBag-unique g' homo-g'
+  where
+    g : a → b
+    g = λ x → mempty {b} {{iMb .Monoid.monoid}}
+
+    g' : Bag a → b
+    g' = λ xs → mempty
+
+    lemma : g' ∘ singleton ≡ g
+    lemma = refl
+
+    homo-g' : Monoid.IsHomomorphism g'
+    homo-g' .Monoid.homo-mempty = refl
+    homo-g' .Monoid.homo-<> xs ys = sym (Monoid.leftIdentity _)
+
+-- | 'foldBag' is a homomorphism on functions as well.
+-- 
+-- Note: This property requires commutativity of the image monoid!
+-- It does not generally hold for the 'Foldable' class.
+--
+prop-foldBag-function-<>
+  : ∀ ⦃ _ : Monoid.Commutative b ⦄ ⦃ _ : IsLawfulMonoid b ⦄
+      (f g : a → b) (xs : Bag a)
+  → foldBag (λ x → f x <> g x) xs
+    ≡ foldBag f xs <> foldBag g xs
+--
+prop-foldBag-function-<> {a} f g =
+    prop-Bag-equality lhs rhs lhs-homo rhs-homo (λ x → refl)
+  where
+    lhs = λ xs → foldBag (λ x → f x <> g x) xs
+    rhs = λ xs → foldBag f xs <> foldBag g xs
+
+    lhs-homo : Monoid.IsHomomorphism lhs
+    lhs-homo = prop-morphism-foldBag _
+
+    @0 rhs-homo : Monoid.IsHomomorphism rhs
+    rhs-homo .Monoid.homo-mempty
+      = Monoid.leftIdentity mempty
+    rhs-homo .Monoid.homo-<> xs ys
+      = begin
+        (foldBag f xs <> foldBag f ys)
+          <> (foldBag g xs <> foldBag g ys)
+      ≡⟨ sym (Monoid.associativity _ _ _) ⟩
+        foldBag f xs <>
+          (foldBag f ys <> (foldBag g xs
+            <> foldBag g ys))
+      ≡⟨ cong (λ o → foldBag f xs <> o) (Monoid.associativity _ _ _) ⟩
+        foldBag f xs <>
+          ((foldBag f ys <> foldBag g xs)
+            <> foldBag g ys)
+      ≡⟨ cong (λ o → foldBag f xs <> (o <> foldBag g ys)) (Monoid.commutative _ _) ⟩
+        foldBag f xs <>
+          ((foldBag  g xs <> foldBag f ys)
+            <> foldBag g ys)
+      ≡⟨ cong (λ o → foldBag f xs <> o) (sym (Monoid.associativity _ _ _)) ⟩
+        foldBag f xs <>
+          (foldBag g xs <> (foldBag f ys)
+            <> foldBag g ys)
+      ≡⟨ Monoid.associativity _ _ _ ⟩
+        rhs xs <> rhs ys
+      ∎
+
+-- | 'foldBag' that maps to 'singleton' is the identity.
+prop-foldBag-function-singleton
+  : ∀ ⦃ _ : Monoid.Commutative b ⦄ (xs : Bag b)
+  → foldBag (λ x → singleton x) xs ≡ xs
+--
+prop-foldBag-function-singleton =
+  prop-foldBag-unique _ Monoid.prop-morphism-id

--- a/lib/bags/agda/Data/Bag/Def.agda
+++ b/lib/bags/agda/Data/Bag/Def.agda
@@ -1,0 +1,118 @@
+
+-- | Operations on 'Bag' defined in terms of the axiomatization.
+module Data.Bag.Def where
+
+open import Haskell.Prim
+open import Haskell.Prim.Alternative
+open import Haskell.Prim.Applicative
+open import Haskell.Prim.Eq
+open import Haskell.Prim.Foldable using (foldMap)
+open import Haskell.Prim.Functor
+open import Haskell.Prim.Int
+open import Haskell.Prim.Maybe
+open import Haskell.Prim.Monad
+open import Haskell.Prim.MonadPlus
+open import Haskell.Prim.Monoid
+open import Haskell.Prim.Num
+open import Haskell.Prim.Ord
+open import Haskell.Prim.Tuple
+
+open import Haskell.Law.Function
+open import Haskell.Law.Num
+
+open import Data.Bag.Core
+import Data.Monoid.Refinement as Monoid
+
+{-----------------------------------------------------------------------------
+    Operations
+    basic
+------------------------------------------------------------------------------}
+-- | Test whether the 'Bag' is empty.
+null : Bag a → Bool
+null = foldBag {{Monoid.CommutativeConj}} (λ _ → False)
+
+-- | Union of all items from the two arguments.
+-- Synonym for '(<>)'.
+union : Bag a → Bag a → Bag a
+union = _<>_
+
+-- | A 'Bag' that may contain an element.
+fromMaybe : Maybe a → Bag a
+fromMaybe Nothing  = mempty
+fromMaybe (Just x) = singleton x
+
+-- | Number of items in the Bag.
+size : Bag a → Int
+size = foldBag {{Monoid.CommutativeSum}} (λ _ → 1)
+
+-- | Apply a function to all elements in the 'Bag'
+-- and take the union of the results.
+concatMap : (a → Bag b) → Bag a → Bag b
+concatMap = foldBag
+
+-- | Apply a function to all elements in the 'Bag'.
+map : (a → b) → Bag a → Bag b
+map f = concatMap (singleton ∘ f)
+
+-- | Obtain a 'Bag' with the same items as a given list.
+fromList : List a → Bag a
+fromList = foldMap singleton
+
+{-----------------------------------------------------------------------------
+    Operations
+    functorial type classes
+------------------------------------------------------------------------------}
+instance
+  iDefaultFunctorBag : DefaultFunctor Bag
+  iDefaultFunctorBag .DefaultFunctor.fmap = map
+
+  iFunctorBag : Functor Bag
+  iFunctorBag = record{DefaultFunctor iDefaultFunctorBag}
+
+  iDefaultApplicativeBag : DefaultApplicative Bag
+  iDefaultApplicativeBag .DefaultApplicative.pure = singleton
+  iDefaultApplicativeBag .DefaultApplicative._<*>_ fs xs =
+    concatMap (λ f → map f xs) fs
+
+  iApplicativeBag : Applicative Bag
+  iApplicativeBag = record{DefaultApplicative iDefaultApplicativeBag}
+
+  iDefaultMonadBag : DefaultMonad Bag
+  iDefaultMonadBag .DefaultMonad._>>=_ = flip concatMap
+
+  iMonadBag : Monad Bag
+  iMonadBag = record{DefaultMonad iDefaultMonadBag}
+
+  iAlternativeBag : Alternative Bag
+  iAlternativeBag .Alternative.empty = mempty
+  iAlternativeBag .Alternative._<|>_ = _<>_
+
+  iMonadPlusBag : MonadPlus Bag
+  iMonadPlusBag = record { unique-applicative = refl }
+
+{-----------------------------------------------------------------------------
+    Operations
+    Definitions using do-notation
+------------------------------------------------------------------------------}
+-- | Keep only those elements that satisfy a predicate.
+filter : (a → Bool) → Bag a → Bag a
+filter p xs = do x ← xs; guard (p x); pure x
+
+-- | Count the number of times that an item is contained in the 'Bag'.
+count : ⦃ Eq a ⦄ → a → Bag a → Int
+count x = size ∘ filter (x ==_)
+
+-- | Check whether an item is contained in the 'Bag' at least once.
+member : ⦃ Eq a ⦄ → a → Bag a → Bool
+member x ys = 0 < count x ys
+
+-- | 'Bag' containing all possible pairs of items.
+cartesianProduct : Bag a → Bag b → Bag (a × b)
+cartesianProduct xs ys = do x ← xs; y ← ys; pure (x , y)
+
+-- | 'Bag' containing all possible pairs of items where
+-- the functions yield the same result.
+equijoin
+    : ∀ {k} ⦃ _ : Eq k ⦄
+    → (a → k) → (b → k) → Bag a → Bag b → Bag (a × b)
+equijoin f g xs ys = do x ← xs; y ← ys; guard (f x == g y); pure (x , y)

--- a/lib/bags/agda/Data/Bag/Prop.agda
+++ b/lib/bags/agda/Data/Bag/Prop.agda
@@ -1,0 +1,281 @@
+
+-- | Proofs on 'Bag'.
+module Data.Bag.Prop where
+
+open import Haskell.Prelude hiding (lookup; null; map; filter)
+
+open import Data.Bag.Core
+open import Data.Bag.Def
+
+open import Haskell.Prim.Alternative
+open import Haskell.Prim.MonadPlus
+open import Haskell.Law
+open import Haskell.Law.Extensionality
+open import Haskell.Law.Monad.Extra
+open import Haskell.Law.MonadPlus
+open import Haskell.Law.Num
+
+import Haskell.Prim.List as List
+import Haskell.Law.Monad as Monad
+import Haskell.Law.Monoid as Monoid
+
+import Data.Monoid.Morphism as Monoid
+import Data.Monoid.Refinement as Monoid
+
+------------------------------------------------------------------------------
+-- Move out: Additional type of monad
+
+record IsCommutativeMonad (m : Type → Type) ⦃ _ : Monad m ⦄ : Type₁ where
+  field
+    -- Different monadic actions commute
+    prop-monad-sym : ∀ {a b : Type} (mx : m a) (my : m b) (mz : a → b → m c)
+      → mx >>= (λ x → my >>= (λ y → mz x y))
+        ≡ my >>= (λ y → mx >>= (λ x → mz x y))
+
+------------------------------------------------------------------------------
+-- Move out: Helper function for proofs on monads
+
+cong-monad
+  : ∀ ⦃ _ : Monad m ⦄ (mx : m a) (f g : a → m b)
+  → (∀ x → f x ≡ g x)
+  → (do x ← mx; f x) ≡ (do x ← mx; g x)
+cong-monad mx f g eq = cong (mx >>=_) (ext eq)
+
+{-----------------------------------------------------------------------------
+    Properties
+    size
+------------------------------------------------------------------------------}
+{- [Rewrite size]
+
+The properties of 'size' follow automatically from the rewrite rules
+for 'foldBag'.
+-}
+
+-- | A 'singleton' has @'size' = 1@.
+prop-size-singleton : ∀ (x : a) → size (singleton x) ≡ 1
+--
+prop-size-singleton x = refl
+
+-- | The empty 'Bag' has @'size' = 0@.
+prop-size-mempty : ∀ {a} → size {a} mempty ≡ 0
+--
+prop-size-mempty = refl
+
+-- | The union of 'Bags' adds their sizes.
+prop-size-<> : ∀ (xs ys : Bag a) → size (xs <> ys) ≡ size xs + size ys
+--
+prop-size-<> xs ys = refl
+
+{-----------------------------------------------------------------------------
+    Properties
+    functorial type classes
+------------------------------------------------------------------------------}
+-- | 'map'ping the identity function leaves the result unchanged.
+prop-map-id : ∀ (xs : Bag a) → map id xs ≡ xs
+-- 
+prop-map-id xs = prop-foldBag-unique id Monoid.prop-morphism-id xs
+
+-- | 'map'ping a composition of functions gives the composition.
+prop-map-∘
+  : ∀ (f : a → b) (g : b → c) (xs : Bag a)
+  → map (g ∘ f) xs ≡ (map g ∘ map f) xs
+--
+prop-map-∘ f g =
+    prop-Bag-equality lhs rhs lhs-homo rhs-homo (λ x → refl)
+  where
+    lhs = map (g ∘ f)
+    rhs = map g ∘ map f
+
+    lhs-homo : Monoid.IsHomomorphism lhs
+    lhs-homo = prop-morphism-foldBag _
+
+    @0 rhs-homo : Monoid.IsHomomorphism rhs
+    rhs-homo =
+      Monoid.prop-morphism-∘ (map f) (map g)
+        (prop-morphism-foldBag _)
+        (prop-morphism-foldBag _)
+
+instance
+  iLawfulFunctorBag : IsLawfulFunctor Bag
+  iLawfulFunctorBag .identity = prop-map-id
+  iLawfulFunctorBag .composition xs f g = prop-map-∘ f g xs
+
+-- postulated for now, need universal property on `foldBag`
+-- that can deal with predicates.
+postulate instance
+  iLawfulMonadBag : IsLawfulMonad Bag
+
+instance
+  iLawfulMonadPlusBag : IsLawfulMonadPlus Bag
+  iLawfulMonadPlusBag .mplus-mzero-x = Monoid.leftIdentity
+  iLawfulMonadPlusBag .mplus-x-mzero = Monoid.rightIdentity
+  iLawfulMonadPlusBag .mplus-assoc x y z = sym (Monoid.associativity x y z)
+  iLawfulMonadPlusBag .mzero-bind k = refl
+  iLawfulMonadPlusBag .bind-mzero = prop-foldBag-function-mempty
+
+postulate instance
+  iDistributiveMonadPlusBag : IsDistributiveMonadPlus Bag
+  iCommutativeMonadBag      : IsCommutativeMonad Bag
+
+{-----------------------------------------------------------------------------
+    Properties
+    fromList
+------------------------------------------------------------------------------}
+-- | 'fromList' maps single element lists to singleton
+prop-fromList-[] : ∀ {a} → fromList {a} [] ≡ mempty
+--
+prop-fromList-[] = refl
+
+-- | 'fromList' maps list concatenation to 'union' of 'Bag's.
+prop-fromList-++
+  : ∀ (xs ys : List a) 
+  → fromList (xs ++ ys) ≡ fromList xs <> fromList ys
+--
+prop-fromList-++ [] ys = sym (Monoid.leftIdentity _)
+prop-fromList-++ (x ∷ xs) ys
+  rewrite ∷-++-assoc x xs ys
+  rewrite prop-fromList-++ xs ys
+  rewrite Monoid.associativity (singleton x) (fromList xs) (fromList ys)
+  = refl
+
+-- | 'fromList' preserves list length.
+prop-size-fromList
+  : ∀ (xs : List a)
+  → size (fromList xs) ≡ length xs
+--
+prop-size-fromList [] = refl
+prop-size-fromList (x ∷ xs) rewrite prop-size-fromList xs = refl
+
+-- | 'fromList' maps 'Data.List.filter' to 'filter'.
+prop-fromList-filter
+  : ∀ (p : a → Bool) (xs : List a) 
+  → fromList (List.filter p xs) ≡ filter p (fromList xs)
+--
+prop-fromList-filter p [] = refl
+prop-fromList-filter p (x ∷ xs)
+  with p x
+... | False
+    rewrite Monoid.leftIdentity (filter p (fromList xs))
+    = prop-fromList-filter p xs
+... | True
+    rewrite prop-fromList-filter p xs
+    = refl
+
+{-----------------------------------------------------------------------------
+    Properties
+    Homomorphisms
+------------------------------------------------------------------------------}
+-- | 'size' is a monoid homomorphism.
+prop-morphism-size
+  : Monoid.IsHomomorphism ⦃ iMonoidBag {a} ⦄ ⦃ MonoidSum ⦄ size
+--
+prop-morphism-size = prop-morphism-foldBag ⦃ Monoid.CommutativeSum ⦄ _
+
+-- | 'fromList' is a monoid homomorphism.
+prop-morphism-fromList
+  : Monoid.IsHomomorphism (fromList {a})
+--
+prop-morphism-fromList =
+  Monoid.MkIsHomomorphism prop-fromList-[] prop-fromList-++
+
+-- | 'filter' is a monoid homomorphism.
+prop-morphism-filter
+  : ∀ (p : a → Bool) → Monoid.IsHomomorphism (filter p)
+--
+prop-morphism-filter p = prop-morphism-foldBag _
+
+-- | 'null' is a monoid homomorphism.
+prop-morphism-null
+  : Monoid.IsHomomorphism ⦃ iMonoidBag {a} ⦄ ⦃ MonoidConj ⦄ null
+--
+prop-morphism-null = prop-morphism-foldBag ⦃ Monoid.CommutativeConj ⦄ _
+
+-- | 'cartesianProduct' is a monoid homomorphism in its first argument.
+prop-morphism-cartesianProduct-1
+  : ∀ (ys : Bag b)
+  → Monoid.IsHomomorphism (λ xs → cartesianProduct {a} {b} xs ys)
+--
+prop-morphism-cartesianProduct-1 ys = prop-morphism-foldBag _
+
+-- | 'cartesianProduct' is a monoid homomorphism in its second argument.
+prop-morphism-cartesianProduct-2
+  : ∀ (xs : Bag a)
+  → Monoid.IsHomomorphism (λ (ys : Bag b) → cartesianProduct {a} {b} xs ys)
+--
+prop-morphism-cartesianProduct-2 xs .Monoid.homo-mempty =
+  prop-foldBag-function-mempty xs
+prop-morphism-cartesianProduct-2 xs .Monoid.homo-<> ys1 ys2 =
+  prop-foldBag-function-<> _ _ xs
+
+-- | 'equijoin' is a monoid homomorphism in its first argument.
+prop-morphism-equijoin-1
+  : ∀ {k} ⦃ _ : Eq k ⦄ (f : a → k) (g : b → k) (ys : Bag b)
+  → Monoid.IsHomomorphism (λ xs → equijoin f g xs ys)
+--
+prop-morphism-equijoin-1 f g ys = prop-morphism-foldBag _
+
+-- | 'equijoin' is a monoid homomorphism in its second argument.
+prop-morphism-equijoin-2
+  : ∀ {k} ⦃ _ : Eq k ⦄ (f : a → k) (g : b → k) (xs : Bag a)
+  → Monoid.IsHomomorphism (λ ys → equijoin f g xs ys)
+--
+prop-morphism-equijoin-2 f g xs .Monoid.homo-mempty =
+  prop-foldBag-function-mempty xs
+prop-morphism-equijoin-2 f g xs .Monoid.homo-<> x y =
+  prop-foldBag-function-<> _ _ xs
+
+{-----------------------------------------------------------------------------
+    Properties
+    cartesianProduct
+------------------------------------------------------------------------------}
+-- | A 'cartesianProduct' is empty if and only if both arguments are empty.
+postulate
+ prop-null-cartesianProduct
+  : ∀ (xs : Bag a) (ys : Bag b)
+  → null (cartesianProduct xs ys) ≡ (null xs || null ys)
+--
+{-
+prop-null-cartesianProduct =
+    prop-Bag-equality-2 lhs rhs
+      (λ xs → Monoid.prop-morphism-∘ _ _ (prop-morphism-cartesianProduct-2 xs) prop-morphism-null)
+      ?
+      (λ ys → Monoid.prop-morphism-∘ _ _ (prop-morphism-cartesianProduct-1 ys) prop-morphism-null)
+      ?
+      eq-singleton
+  where 
+    lhs = λ xs ys → null (cartesianProduct xs ys)
+    rhs = λ xs ys → (null xs || null ys)
+    eq-singleton
+      : ∀ x y → lhs (singleton x) (singleton y) ≡ rhs (singleton x) (singleton y)
+    eq-singleton x y = ?
+-}
+
+{-----------------------------------------------------------------------------
+    Properties
+    filter
+------------------------------------------------------------------------------}
+-- | Independent filters promote through cartesian product.
+prop-filter-cartesianProduct
+  : ∀ (p : a → Bool) (q : b → Bool) (xs : Bag a) (ys : Bag b)
+  → filter (λ xy → p (fst xy) && q (snd xy)) (cartesianProduct xs ys)
+    ≡ cartesianProduct (filter p xs) (filter q ys)
+--
+prop-filter-cartesianProduct p q =
+    prop-Bag-equality-2 lhs rhs
+      (λ xs → Monoid.prop-morphism-∘ _ _ (prop-morphism-cartesianProduct-2 xs) (prop-morphism-filter r))
+      (λ xs → Monoid.prop-morphism-∘ _ _ (prop-morphism-filter q) (prop-morphism-cartesianProduct-2 (filter p xs)))
+      (λ ys → Monoid.prop-morphism-∘ _ _ (prop-morphism-cartesianProduct-1 ys) (prop-morphism-filter r))
+      (λ ys → Monoid.prop-morphism-∘ _ _ (prop-morphism-filter p) (prop-morphism-cartesianProduct-1 (filter q ys)))
+      eq-singleton
+  where 
+    r   = λ xy → p (fst xy) && q (snd xy)
+    lhs = λ xs ys → filter r (cartesianProduct xs ys)
+    rhs = λ xs ys → cartesianProduct (filter p xs) (filter q ys)
+    eq-singleton
+      : ∀ x y → lhs (singleton x) (singleton y) ≡ rhs (singleton x) (singleton y)
+    eq-singleton x y
+      with p x | q y
+    ... | True  | True  = refl
+    ... | True  | False = refl
+    ... | False | True  = refl
+    ... | False | False = refl

--- a/lib/bags/agda/Data/BagOld.agda
+++ b/lib/bags/agda/Data/BagOld.agda
@@ -1,0 +1,220 @@
+{-# OPTIONS --erasure #-}
+
+module Data.BagOld
+  {-|
+  -- * Data
+  -- ** Bag Type
+  ; Bag
+  -- ** Construction
+  ; empty
+  ; singleton
+  ; fromList
+  ; guard
+  -- ** Query
+  ; member
+  -- ** Combine
+  ; union
+  -- ** Filter
+  ; filter
+    ; prop-filter-guard
+
+  -- * Properties
+  -} where
+
+open import Haskell.Prelude hiding (filter)
+open import Haskell.Law
+
+{-----------------------------------------------------------------------------
+    Type
+------------------------------------------------------------------------------}
+-- | A unordered, finite collection of items.
+-- Items may appear more than once.
+--
+-- Bag is the free commutative monoid.
+record Bag (a : Type) : Type where
+  constructor MkBag
+  field
+    elements : List a
+
+open Bag public
+
+{-# COMPILE AGDA2HS Bag #-}
+
+{-----------------------------------------------------------------------------
+    Construction
+------------------------------------------------------------------------------}
+
+-- | The empty 'Bag'.
+empty : Bag a
+empty = MkBag []
+
+{-# COMPILE AGDA2HS empty #-}
+
+-- | 'Bag' with a single element.
+singleton : a → Bag a
+singleton x = MkBag (x ∷ [])
+
+{-# COMPILE AGDA2HS singleton #-}
+
+-- | Create a 'Bag' from a list of items.
+fromList : List a → Bag a
+fromList = MkBag
+
+{-# COMPILE AGDA2HS fromList #-}
+
+-- | Return a 'Bag' with one element if the condition is 'True',
+-- and 'empty' if the condition is 'False'.
+-- Very useful for @do@ notation.
+--
+-- From "Control.Monad".
+guard : Bool → Bag ⊤
+guard True = singleton tt
+guard False = empty
+
+{-# COMPILE AGDA2HS guard #-}
+
+-- Special syntax for highlighting that an expression is a bag.
+-- Escape sequences:
+-- ⟅ = \(9
+-- ⟆ = \)9
+⟅_⟆ : Bag a → Bag a
+⟅_⟆ x = x
+
+{-----------------------------------------------------------------------------
+    Query
+------------------------------------------------------------------------------}
+-- | Is the item in the 'Bag'?
+member : ⦃ Eq a ⦄ → a → Bag a → Bool
+member x (MkBag xs) = elem x xs
+
+{-# COMPILE AGDA2HS member #-}
+
+-- | Delete the first occurrence of an item from the list.
+-- Return 'Nothing' if the element does not occur.
+delete1 : ⦃ Eq a ⦄ → a → List a → Maybe (List a)
+delete1 x [] = Nothing
+delete1 x (y ∷ ys) = if x == y then Just ys else fmap (y ∷_) (delete1 x ys)
+
+{-# COMPILE AGDA2HS delete1 #-}
+
+-- | Two lists are equal as bags.
+eqBag : ⦃ Eq a ⦄ →  List a → List a → Bool
+eqBag []       []       = True
+eqBag []       (y ∷ ys) = False
+eqBag (x ∷ xs) ys'      = case delete1 x ys' of λ where
+    (Just ys) → eqBag xs ys
+    Nothing   → False
+
+{-# COMPILE AGDA2HS eqBag #-}
+
+instance
+  iEqBag : ⦃ Eq a ⦄ → Eq (Bag a)
+  iEqBag ._==_ (MkBag xs) (MkBag ys) = eqBag xs ys
+
+{-# COMPILE AGDA2HS iEqBag derive #-}
+
+postulate instance
+  iLawfulEqBag : ⦃ _ : Eq a ⦄ → ⦃ IsLawfulEq a ⦄ → IsLawfulEq (Bag a)
+
+instance
+  iDefaultFunctorBag : DefaultFunctor Bag
+  iDefaultFunctorBag .DefaultFunctor.fmap f (MkBag xs) = MkBag (fmap f xs)
+
+  iFunctorBag : Functor Bag
+  iFunctorBag = record {DefaultFunctor iDefaultFunctorBag}
+
+  -- Not sure what is going on here, but using
+  --   iDefaultApplicativeBag : DefaultApplicative Bag
+  -- emits *two* definitions for `pure` and `<*>`.
+  --
+  -- Using an explicit `record` in `iApplicativeBag` yields
+  -- triggers a bug in agda2hs / Agda:
+  --   __IMPOSSIBLE__,
+  --   called at src/full/Agda/TypeChecking/Telescope.hs:625:28
+  --   in Agda-2.7.0-4AYHYh2TvbO6boiLogUmpv:Agda.TypeChecking.Telescope
+  iApplicativeBag : Applicative Bag
+  iApplicativeBag .pure = λ x → MkBag (pure x)
+  iApplicativeBag ._<*>_ = λ fs xs → MkBag (elements fs <*> elements xs)
+  iApplicativeBag ._<*_ = λ fs xs → MkBag (elements fs <* elements xs)
+  iApplicativeBag ._*>_ = λ fs xs → MkBag (elements fs *> elements xs)
+
+  iDefaultMonadBag : DefaultMonad Bag
+  iDefaultMonadBag .DefaultMonad._>>=_ (MkBag m) f =
+    MkBag (m >>= (elements ∘ f))
+
+  iMonadBag : Monad Bag
+  iMonadBag = record {DefaultMonad iDefaultMonadBag}
+
+{-# COMPILE AGDA2HS iFunctorBag #-}
+{-# COMPILE AGDA2HS iApplicativeBag #-}
+{-# COMPILE AGDA2HS iMonadBag #-}
+
+{-----------------------------------------------------------------------------
+    Combine
+------------------------------------------------------------------------------}
+-- | The union of two 'Bag's contains all items from each of the 'Bag's.
+--
+-- 'union' is commutative.
+union : Bag a → Bag a → Bag a
+union (MkBag xs) (MkBag ys) = MkBag (xs <> ys)
+
+{-# COMPILE AGDA2HS union #-}
+
+instance
+  iSemigroupBag : Semigroup (Bag a)
+  iSemigroupBag ._<>_ = union
+
+  iDefaultMonoidBag : DefaultMonoid (Bag a)
+  iDefaultMonoidBag .DefaultMonoid.mempty = empty
+
+  iMonoidBag : Monoid (Bag a)
+  iMonoidBag = record{DefaultMonoid iDefaultMonoidBag}
+
+{-# COMPILE AGDA2HS iSemigroupBag #-}
+{-# COMPILE AGDA2HS iMonoidBag #-}
+
+{-----------------------------------------------------------------------------
+    Filter
+------------------------------------------------------------------------------}
+-- | Filter all elements that satisfy the predicate.
+filter : (a → Bool) → Bag a → Bag a
+filter = λ p xs → do
+  x ← xs
+  guard (p x)
+  pure x
+
+{-# COMPILE AGDA2HS filter #-}
+
+-- | 'filter' can be written using @do@ notation with a 'guard'.
+-- 
+prop-filter-guard
+  : ∀ ⦃ _ : Eq a ⦄ ⦃ _ : IsLawfulEq a ⦄ (p : a → Bool) (xs : Bag a)
+  → (filter p xs
+    == (do x ← xs; guard (p x); pure x)) ≡ True
+--
+prop-filter-guard p xs = equality' (filter p xs) _ refl
+
+{-----------------------------------------------------------------------------
+    Properties
+------------------------------------------------------------------------------}
+-- | 'Bag' is a commutative monad.
+--
+postulate
+ prop-monad-sym
+  : ∀ ⦃ _ : Eq a ⦄ (xs ys : Bag a)
+  → ((do x ← xs; y ← ys; pure (x , y))
+    == (do y ← ys; x ← xs; pure (x , y))) ≡ True
+
+{-----------------------------------------------------------------------------
+    Examples
+------------------------------------------------------------------------------}
+
+example0 : Bag Integer
+example0 = fromList (1 ∷ 2 ∷ 3 ∷ 4 ∷ 5 ∷ 6 ∷ [])
+
+example1 : Bag Integer
+example1 = do
+  x ← example0
+  y ← example0
+  guard (x == y)
+  pure (x + y)

--- a/lib/bags/agda/Data/Indexed.agda
+++ b/lib/bags/agda/Data/Indexed.agda
@@ -1,0 +1,4 @@
+module Data.Indexed where
+
+open import Data.Indexed.Def  public
+open import Data.Indexed.Prop public

--- a/lib/bags/agda/Data/Indexed/Def.agda
+++ b/lib/bags/agda/Data/Indexed/Def.agda
@@ -1,0 +1,251 @@
+{-# OPTIONS --irrelevant-projections #-}
+
+-- | Indexed Tables and operations on them.
+module Data.Indexed.Def where
+
+open import Haskell.Prelude hiding (lookup; null)
+
+open import Data.Bag using (Bag; null; foldBag)
+import Data.Bag as Bag
+open import Data.Map using (Map)
+import Data.Map as Map
+
+open import Haskell.Law.Equality
+open import Haskell.Law.Extensionality
+open import Haskell.Law.Maybe using (Just-injective)
+
+import Data.Monoid.Morphism as Monoid
+import Data.Monoid.Refinement as Monoid
+
+------------------------------------------------------------------------------
+-- Move out: Elimination of irrelevant ⊥
+
+⊥-elim-irr : ∀ {ℓ} {Whatever : Type ℓ} → .⊥ → Whatever
+⊥-elim-irr ()
+
+------------------------------------------------------------------------------
+-- Move out: Helper function on "Data.Maybe"
+
+isJust : Maybe a → Bool
+isJust Nothing = False
+isJust (Just x) = True
+
+{-----------------------------------------------------------------------------
+    Raw operations
+------------------------------------------------------------------------------}
+mergeRaw
+  : ∀ {k} ⦃ _ : Ord k ⦄
+  → Map k (Bag a) → Map k (Bag b) → Map k (Bag (a × b))
+mergeRaw = Map.intersectionWith Bag.cartesianProduct
+
+{-----------------------------------------------------------------------------
+    Invariant
+------------------------------------------------------------------------------}
+-- | Invariant satisfied by the map inside 'Table':
+--
+-- The 'Map' is normalized to not contain explicit 'mempty' items.
+Is-lookup-not-null : ∀ {k} ⦃ _ : Ord k ⦄ → Map k (Bag a) → Type
+Is-lookup-not-null {k = k} = λ xs →
+    ∀ (key : k) → (fmap null (Map.lookup key xs) == Just True) ≡ False
+
+--
+prop-invariant-mempty
+  : ∀ {a k} ⦃ _ : Ord k ⦄ → Is-lookup-not-null {a} {k} Map.empty
+--
+prop-invariant-mempty {a} key
+  rewrite Map.prop-lookup-empty {_} {Bag a} key
+  = refl
+
+--
+prop-invariant-singleton
+  : ∀ {a k} ⦃ _ : Ord k ⦄ {key : k} {x : a}
+  → Is-lookup-not-null {a} {k} (Map.singleton key (Bag.singleton x))
+--
+prop-invariant-singleton {a} {k} {key} {x} key'
+  rewrite Map.prop-lookup-singleton {_} {Bag a} key' key (Bag.singleton x)
+  with (key' == key)
+... | False = refl
+... | True  = refl
+
+--
+prop-invariant-unionWith
+  : ∀ {k} ⦃ _ : Ord k ⦄ {xs ys : Map k (Bag a)}
+  → Is-lookup-not-null xs
+  → Is-lookup-not-null ys
+  → Is-lookup-not-null (Map.unionWith (_<>_) xs ys)
+--
+prop-invariant-unionWith {xs = xs} {ys = ys} cond-xs cond-ys key
+  rewrite Map.prop-lookup-unionWith key (_<>_) xs ys
+  with cx ← cond-xs key
+  with cy ← cond-ys key
+  with Map.lookup key xs | Map.lookup key ys
+... | Nothing | Nothing = refl
+... | Nothing | Just y  = cy
+... | Just x  | Nothing = cx
+... | Just x  | Just y
+    with null x
+...     | False = refl
+        -- This case holds for Bags, but not for general monoids,
+        -- where two items can cancel each other.
+
+--
+prop-invariant-mergeRaw
+  : ∀ {k} ⦃ _ : Ord k ⦄ {xs : Map k (Bag a)} {ys : Map k (Bag b)}
+  → Is-lookup-not-null xs
+  → Is-lookup-not-null ys
+  → Is-lookup-not-null (mergeRaw xs ys)
+--
+prop-invariant-mergeRaw {xs = xs} {ys = ys} cond-xs cond-ys key
+  rewrite Map.prop-lookup-intersectionWith key xs ys Bag.cartesianProduct
+  with cx ← cond-xs key
+  with cy ← cond-ys key
+  with Map.lookup key xs | Map.lookup key ys
+... | Nothing | Nothing = refl
+... | Nothing | Just y  = refl
+... | Just x  | Nothing = refl
+... | Just x  | Just y  
+    rewrite Bag.prop-null-cartesianProduct x y
+    with null x
+...   | True  = cx
+...   | False = cy
+
+{-----------------------------------------------------------------------------
+    Data type
+------------------------------------------------------------------------------}
+-- | An indexed 'Table' is a finite map from keys (indices) to finite bags
+-- of values.
+--
+-- This type can also be viewed as a 'Bag' where elements have been grouped
+-- by keys.
+record Table k a ⦃ @0 _ : Ord k ⦄ : Type where
+  constructor MkTable
+  field
+    getTable : Map k (Bag a)
+    @0 . invariant-lookup : Is-lookup-not-null getTable
+
+open Table public
+
+-- | Two Tables are equal if they contain the same 'Map'.
+@0 prop-Table-equality
+  : ∀ {k} ⦃ _ : Ord k ⦄ {xs ys : Table k a}
+  → getTable xs ≡ getTable ys
+  → xs ≡ ys
+prop-Table-equality refl = refl
+
+{-----------------------------------------------------------------------------
+    Operations
+------------------------------------------------------------------------------}
+-- Helper function for 'lookup'.
+toBag : Maybe (Bag a) → Bag a
+toBag Nothing  = mempty
+toBag (Just x) = x
+
+-- | Look up an index in a 'Table'.
+lookup : ∀ {k} ⦃ _ : Ord k ⦄ → k → Table k a → Bag a
+lookup = λ key → toBag ∘ Map.lookup key ∘ getTable
+
+-- | Table with a single item.
+singleton : ∀ {k} ⦃ _ : Ord k ⦄ → k → a → Table k a
+singleton key x =
+  MkTable (Map.singleton key (Bag.singleton x)) prop-invariant-singleton
+
+instance
+  iSemigroupTable : ∀ {k} ⦃ _ : Ord k ⦄ → Semigroup (Table k a)
+  iSemigroupTable ._<>_ (MkTable xs inv-x) (MkTable ys inv-y) =
+    MkTable (Map.unionWith (_<>_) xs ys) (prop-invariant-unionWith inv-x inv-y)
+
+  iDefaultMonoidTable : ∀ {k} ⦃ _ : Ord k ⦄ → DefaultMonoid (Table k a)
+  iDefaultMonoidTable .DefaultMonoid.mempty =
+    MkTable Map.empty prop-invariant-mempty
+
+  iMonoidTable : ∀ {k} ⦃ _ : Ord k ⦄ → Monoid (Table k a)
+  iMonoidTable = record{DefaultMonoid iDefaultMonoidTable}
+
+-- | The semigroup operation on 'Table' is commutative.
+@0 prop-Table-<>-sym
+  : ∀ {k} ⦃ _ : Ord k ⦄ (xs ys : Table k a)
+  → xs <> ys ≡ ys <> xs
+--
+prop-Table-<>-sym {a} (MkTable xs inv-x) (MkTable ys inv-y)
+  = prop-Table-equality eq-Table
+  where
+    eq-Table : Map.unionWith (_<>_) xs ys ≡ Map.unionWith (_<>_) ys xs
+    eq-Table
+      rewrite Map.prop-unionWith-sym {f = _<>_} {xs} {ys}
+      = cong (λ o → Map.unionWith o ys xs) (sym (ext₂ Monoid.commutative))
+
+instance
+  iCommutativeTable : ∀ {k} ⦃ _ : Ord k ⦄ → Monoid.Commutative (Table k a)
+  iCommutativeTable .Monoid.monoid = iMonoidTable
+  iCommutativeTable .Monoid.commutative = prop-Table-<>-sym
+
+-- | Index the items in a 'Bag' by a function.
+indexBy : ∀ {k} ⦃ _ : Ord k ⦄ → Bag a → (a → k) → Table k a
+indexBy xs f = foldBag (λ x → singleton (f x) x) xs
+
+-- | Forget the index.
+elements : ∀ {k} ⦃ _ : Ord k ⦄ → Table k a → Bag a
+elements = foldMap id ∘ getTable
+
+-- | For each key, return the 'cartesianProduct' of 'Bag's.
+merge : ∀ {k} ⦃ _ : Ord k ⦄ → Table k a → Table k b → Table k (a × b)
+merge xs ys = record
+  { getTable = mergeRaw (getTable xs) (getTable ys)
+  ; invariant-lookup =
+    prop-invariant-mergeRaw (invariant-lookup xs) (invariant-lookup ys)
+  }
+
+{-----------------------------------------------------------------------------
+    Properties
+------------------------------------------------------------------------------}
+-- Helper property that uses the invariant.
+@0 prop-lookup≡mempty→Nothing
+  : ∀ {k} ⦃ _ : Ord k ⦄ (key : k) (xs : Table k a)
+  → (lookup key xs ≡ mempty)
+  → Map.lookup key (getTable xs) ≡ Nothing
+--
+prop-lookup≡mempty→Nothing key xs cond
+  with Map.lookup key (getTable xs) in eq
+... | Nothing = refl
+... | Just x  =
+      ⊥-elim-irr (lemma (invariant-lookup xs) (cong isJust eq))
+  where
+    -- The invariant is marked irrelevant.
+    -- In order to drop the irrelevance, we have to do a proof
+    -- by contradiction.
+    . lemma
+      : Is-lookup-not-null (getTable xs)
+      → isJust (Map.lookup key (getTable xs)) ≡ True
+      → ⊥
+    lemma invariant contr
+      -- making the invariant participate in rewrite
+      -- requires lemma to be irrelevant.
+      with i ← invariant key
+      with Map.lookup key (getTable xs) in eq-y
+    ... | Nothing = case contr of λ ()
+    ... | Just y
+        rewrite Just-injective eq
+        rewrite cond
+        = case i of λ ()
+
+-- | Tables that have the same 'lookup' function are equal.
+@0 prop-lookup→equality
+  : ∀ {k} ⦃ _ : Ord k ⦄ (xs ys : Table k a)
+  → (∀ key → lookup key xs ≡ lookup key ys)
+  → xs ≡ ys
+--
+prop-lookup→equality xs ys cond =
+    prop-Table-equality (Map.prop-equality lemma)
+  where
+    lemma : ∀ key
+      → Map.lookup key (getTable xs)
+        ≡ Map.lookup key (getTable ys)
+    lemma key
+      with cond' ← cond key
+      with lookup-x ← prop-lookup≡mempty→Nothing key xs
+      with lookup-y ← prop-lookup≡mempty→Nothing key ys
+      with Map.lookup key (getTable xs) | Map.lookup key (getTable ys)
+    ... | Nothing | Nothing = refl
+    ... | Nothing | Just y  = sym (lookup-y (sym cond'))
+    ... | Just x  | Nothing = lookup-x cond'
+    ... | Just x  | Just y  = cong Just cond'

--- a/lib/bags/agda/Data/Indexed/Prop.agda
+++ b/lib/bags/agda/Data/Indexed/Prop.agda
@@ -1,0 +1,234 @@
+
+-- | Proofs about indexed 'Table's.
+module Data.Indexed.Prop where
+
+open import Haskell.Prelude hiding (filter; lookup; null)
+
+open import Data.Indexed.Def
+
+open import Data.Bag using (Bag)
+import Data.Bag as Bag
+open import Data.Map using (Map)
+import Data.Map as Map
+import Data.Map.Prop.Extra as Map
+open import Data.Map.Prop.Extra using (prop-if-apply)
+
+open import Haskell.Law.Eq
+open import Haskell.Law.Equality
+open import Haskell.Law.Extensionality
+
+import Haskell.Law.Monoid as Monoid
+import Data.Monoid.Morphism as Monoid
+import Data.Monoid.Refinement as Monoid
+
+{-----------------------------------------------------------------------------
+    Properties
+    Singletons
+------------------------------------------------------------------------------}
+--
+prop-elements-singleton
+  : ∀ {k a} ⦃ _ : Ord k ⦄ (key : k) (x : a)
+  → elements (singleton key x) ≡ Bag.singleton x
+--
+prop-elements-singleton key x
+  rewrite Map.prop-toAscList-singleton key (Bag.singleton x)
+  = Monoid.rightIdentity _
+
+--
+@0 prop-merge-singleton
+  : ∀ {k} ⦃ _ : Ord k ⦄ ⦃ _ : IsLawfulEq k ⦄
+    (keyx : k) (x : a) (keyy : k) (y : b)
+  → merge (singleton keyx x) (singleton keyy y)
+    ≡ (if keyx == keyy then singleton keyx (x , y) else mempty)
+--
+prop-merge-singleton keyx x keyy y =
+  prop-Table-equality
+    (trans lemma (sym (prop-if-apply getTable (keyx == keyy) _ _)))
+  where
+    single : ∀ {c} {k} ⦃ _ : Ord k ⦄ → k → c → Map k (Bag c)
+    single = λ key v → Map.singleton key (Bag.singleton v)
+
+    lemma
+      : mergeRaw (single keyx x) (single keyy y)
+      ≡ (if keyx == keyy then single keyx (x , y) else Map.empty)
+    lemma
+      rewrite Map.prop-intersectionWith-singleton Bag.cartesianProduct keyx (Bag.singleton x) keyy (Bag.singleton y)
+      with keyx == keyy
+    ... | False = refl
+    ... | True  = refl
+
+{-----------------------------------------------------------------------------
+    Properties
+    Homomorphisms
+------------------------------------------------------------------------------}
+-- | 'lookup' is a homomorphism of monoids.
+prop-morphism-lookup
+  : ∀ {a k} ⦃ _ : Ord k ⦄
+  → ∀ (key : k) → Monoid.IsHomomorphism (lookup {a} key)
+--
+prop-morphism-lookup {a} {k} key .Monoid.homo-mempty =
+  cong toBag (Map.prop-lookup-empty key)
+prop-morphism-lookup {a} {k} key .Monoid.homo-<> xs ys
+  rewrite Map.prop-lookup-unionWith key (_<>_) (getTable xs) (getTable ys)
+  with Map.lookup key (getTable xs) | Map.lookup key (getTable ys)
+... | Nothing | Nothing = sym (Monoid.leftIdentity _)
+... | Nothing | Just y  = sym (Monoid.leftIdentity _)
+... | Just x  | Nothing = sym (Monoid.rightIdentity _)
+... | Just x  | Just y  = refl
+
+-- | 'indexBy' is a homomorphism of monoids.
+prop-morphism-indexBy
+  : ∀ {a k} ⦃ _ : Ord k ⦄
+  → ∀ (f : a → k) → Monoid.IsHomomorphism (λ xs → indexBy xs f)
+--
+prop-morphism-indexBy f = Bag.prop-morphism-foldBag _
+
+-- | 'elements' on 'Table' is a homomorphism of monoids.
+@0 prop-morphism-elements
+  : ∀ {a k} ⦃ _ : Ord k ⦄
+  → Monoid.IsHomomorphism (elements {a} {k})
+--
+prop-morphism-elements {a} {k} .Monoid.homo-mempty
+  rewrite Map.prop-toAscList-empty {k} {Bag a}
+  = refl
+prop-morphism-elements .Monoid.homo-<> x y =
+  Map.prop-fold-unionWith (getTable x) (getTable y)
+
+-- | 'merge' is a homomorphism of monoids in its first argument.
+@0 prop-morphism-merge-1
+  : ∀ {k} ⦃ _ : Ord k ⦄
+  → ∀ (ys : Table k b) → Monoid.IsHomomorphism (λ xs → merge {a} xs ys)
+--
+prop-morphism-merge-1 zs .Monoid.homo-mempty =
+  prop-Table-equality (Map.prop-intersectionWith-empty-x _ _)
+prop-morphism-merge-1 zs .Monoid.homo-<> xs ys =
+  prop-Table-equality
+    (Map.prop-intersectionWith-unionWith-x _ _ _ _ _ _
+      (λ x y z → (Bag.prop-morphism-cartesianProduct-1 z .Monoid.homo-<>) x y)
+    )
+
+-- | 'merge' is a homomorphism of monoids in its second argument.
+@0 prop-morphism-merge-2
+  : ∀ {k} ⦃ _ : Ord k ⦄
+  → ∀ (xs : Table k a) → Monoid.IsHomomorphism (λ ys → merge {a} {b} xs ys)
+--
+prop-morphism-merge-2 xs .Monoid.homo-mempty =
+  prop-Table-equality (Map.prop-intersectionWith-x-empty _ _)
+prop-morphism-merge-2 xs .Monoid.homo-<> ys zs =
+  prop-Table-equality
+    (Map.prop-intersectionWith-x-unionWith _ _ _ _ _ _
+      (λ x → Bag.prop-morphism-cartesianProduct-2 x .Monoid.homo-<>)
+    )
+
+-- | 'elements' is an inverse of 'indexBy'.
+@0 prop-elements-indexBy
+  : ∀ {k} ⦃ _ : Ord k ⦄ (xs : Bag a) (f : a → k)
+  → elements (indexBy xs f) ≡ xs
+--
+prop-elements-indexBy {a} {k} xs f =
+    Bag.prop-Bag-equality lhs rhs lhs-homo rhs-homo eq-singleton xs
+  where
+    lhs = λ xs → elements (indexBy xs f)
+    rhs = λ xs → xs
+
+    lhs-homo : Monoid.IsHomomorphism lhs
+    lhs-homo =
+      Monoid.prop-morphism-∘ _ _
+        (prop-morphism-indexBy _) prop-morphism-elements
+
+    rhs-homo = Monoid.prop-morphism-id
+
+    eq-singleton : ∀ x → lhs (Bag.singleton x) ≡ rhs (Bag.singleton x)
+    eq-singleton x = prop-elements-singleton (f x) x
+
+{-----------------------------------------------------------------------------
+    Properties
+------------------------------------------------------------------------------}
+-- | 'indexBy' filters items by 'key'.
+prop-lookup-indexBy
+  : ∀ {k} ⦃ _ : Ord k ⦄ (key : k) (xs : Bag a) (f : a → k)
+  → lookup key (indexBy xs f)
+    ≡ Bag.filter (λ x → key == f x) xs
+--
+prop-lookup-indexBy key xs f =
+    Bag.prop-Bag-equality lhs rhs lhs-homo rhs-homo eq-singleton xs
+  where
+    lhs = λ xs → lookup key (indexBy xs f)
+    rhs = λ xs → Bag.filter (λ x → key == f x) xs
+
+    lhs-homo : Monoid.IsHomomorphism lhs
+    lhs-homo =
+      Monoid.prop-morphism-∘ _ _
+        (prop-morphism-indexBy _) (prop-morphism-lookup key) 
+
+    rhs-homo = Bag.prop-morphism-filter (λ x → key == f x)
+
+    eq-singleton : ∀ x → lhs (Bag.singleton x) ≡ rhs (Bag.singleton x)
+    eq-singleton x
+      rewrite Map.prop-lookup-singleton key (f x) (Bag.singleton x)
+      with key == f x
+    ... | False = refl
+    ... | True  = refl
+
+-- | Using 'indexBy' for each key will give an efficient implementation
+-- implementation of 'equijoin'.
+--
+-- Proof: We use a proof idea that differs from the one in the paper.
+-- Specifically, we use uniqueness of morphism again!
+-- The property holds because:
+--   * When considered as maps from @xs@ or @ys@, the left-hand side
+--     and the right-hand side are monoid homomorphisms, and
+--   * it holds on 'Bag.singleton'.
+@0 prop-equijoin-indexBy
+  : ∀ {k} ⦃ _ : Ord k ⦄ ⦃ _ : IsLawfulEq k ⦄
+      (f : a → k) (g : b → k) (xs : Bag a) (ys : Bag b)
+  → Bag.equijoin f g xs ys
+    ≡ elements (merge (indexBy xs f) (indexBy ys g))
+--
+prop-equijoin-indexBy {a} {b} {k} f g xs ys =
+    Bag.prop-Bag-equality-2 lhs rhs
+      (λ xs → Bag.prop-morphism-equijoin-2 f g xs)
+      (λ xs → Monoid.prop-morphism-∘ _ _
+        (Monoid.prop-morphism-∘ _ _
+          (prop-morphism-indexBy g)
+          (prop-morphism-merge-2 (indexBy xs f))
+        )
+        prop-morphism-elements)
+      (λ ys → Bag.prop-morphism-equijoin-1 f g ys)
+      (λ ys → Monoid.prop-morphism-∘ _ _
+        (Monoid.prop-morphism-∘ _ _
+          (prop-morphism-indexBy f)
+          (prop-morphism-merge-1 (indexBy ys g))
+        )
+        prop-morphism-elements)
+      eq-singleton xs ys
+  where
+    lhs = λ xs ys → Bag.equijoin f g xs ys
+    rhs = λ xs ys → elements (merge (indexBy xs f) (indexBy ys g))
+
+    eq-singleton
+      : ∀ x y
+      → lhs (Bag.singleton x) (Bag.singleton y)
+        ≡ rhs (Bag.singleton x) (Bag.singleton y)
+    eq-singleton x y
+      with f x == g y in eq
+    ... | False =
+        begin
+          mempty
+        ≡⟨ sym (Monoid.homo-mempty prop-morphism-elements) ⟩
+          elements (mempty {Table k (a × b)})
+        ≡⟨ cong (λ o → elements (if o then singleton _ _ else mempty)) (sym eq) ⟩
+          elements (if f x == g y then singleton (f x) (x , y) else mempty)
+        ≡⟨ sym (cong elements (prop-merge-singleton (f x) x (g y) y)) ⟩
+          elements (merge (singleton (f x) x) (singleton (g y) y)) 
+        ∎
+    ... | True  =
+        begin
+          Bag.singleton (x , y)
+        ≡⟨ sym (prop-elements-singleton (f x) (x , y)) ⟩
+          elements (singleton (f x) (x , y))
+        ≡⟨ cong (λ o → elements (if o then singleton _ _ else mempty)) (sym eq) ⟩
+          elements (if f x == g y then singleton (f x) (x , y) else mempty)
+        ≡⟨ sym (cong elements (prop-merge-singleton (f x) x (g y) y)) ⟩
+          elements (merge (singleton (f x) x) (singleton (g y) y)) 
+        ∎

--- a/lib/bags/agda/Data/Map/Prop/Extra.agda
+++ b/lib/bags/agda/Data/Map/Prop/Extra.agda
@@ -1,0 +1,214 @@
+
+module Data.Map.Prop.Extra where
+
+open import Haskell.Prelude hiding (lookup; null; map; filter)
+
+open import Data.Map
+import Haskell.Prelude as List using (lookup)
+
+import Data.Monoid.Refinement as Monoid
+
+open import Haskell.Law.Eq
+open import Haskell.Law.Equality
+
+------------------------------------------------------------------------------
+-- Move out: Properties of if_then_else
+
+prop-if-apply
+  : ∀ (f : a → c) (b : Bool) (t e : a)
+  → f (if b then t else e) ≡ (if b then f t else f e)
+prop-if-apply f True = λ t e → refl
+prop-if-apply f False = λ t e → refl
+
+------------------------------------------------------------------------------
+-- Move out: Utilities for using transitivity of `==`
+
+-- Utlity for transitivity.
+prop-if2then3 : Bool → Bool → Bool → Type
+prop-if2then3 True  True  False = ⊥
+prop-if2then3 True  False True  = ⊥
+prop-if2then3 False True  True  = ⊥
+prop-if2then3 x     y     z     = ⊤
+
+-- | Utility for ruling out cases in 'with' expressions on '(==)'.
+guard-eq-trans
+  : ∀ ⦃ iEq : Eq e ⦄ ⦃ _ : IsLawfulEq e ⦄ (x y z : e)
+  → prop-if2then3 (x == y) (y == z) (x == z)
+--
+guard-eq-trans x y z
+  with x == y in eqxy | y == z in eqyz
+... | False | False = tt
+... | False | True  rewrite sym (equality y z eqyz) | eqxy = tt
+... | True  | False rewrite sym (equality x y eqxy) | eqyz = tt
+... | True  | True  rewrite sym (equality y z eqyz) | eqxy = tt
+
+{-----------------------------------------------------------------------------
+    Proofs
+    toAscList
+------------------------------------------------------------------------------}
+module _ {k : Type} ⦃ _ : Ord k ⦄ where
+
+  postulate
+   prop-lookup-toAscList
+    : ∀ (ma : Map k a) (key : k)
+    → List.lookup key (toAscList ma)
+      ≡ lookup key ma
+
+  postulate
+   prop-fromList-toAscList
+    : ∀ (ma : Map k a)
+    → fromList (toAscList ma) ≡ ma
+
+  -- | For commutative monoids,
+  -- @'unionWith' (<>)@ commutes with 'fold'.
+  postulate
+    prop-fold-unionWith
+      : ∀ ⦃ _ : Monoid.Commutative a ⦄ (ma mb : Map k a)
+      → let fold = foldMap id
+        in  fold (unionWith (_<>_) ma mb)
+              ≡ fold ma <> fold mb
+
+  postulate
+   prop-toAscList-singleton
+    : ∀ (key : k) (x : a)
+    → toAscList (singleton key x) ≡ (key , x) ∷ []
+
+  postulate
+   prop-toAscList-empty
+    : toAscList (empty {k} {a}) ≡ []
+
+{-----------------------------------------------------------------------------
+    Proofs
+    intersectionWith
+------------------------------------------------------------------------------}
+module _ {k : Type} ⦃ _ : Ord k ⦄ where
+
+  -- | 'intersectionWith' an empty 'Map' yields again an empty 'Map'.
+  prop-intersectionWith-empty-x
+    : ∀ (f : a → b → c) (ys : Map k b)
+    → intersectionWith f (empty {k} {a}) ys ≡ empty
+  --
+  prop-intersectionWith-empty-x {a} {b} {c} f ys =
+      prop-equality lemma
+    where
+      lemma
+        : ∀ (key : k)
+        → lookup key (intersectionWith f (empty {k} {a}) ys)
+          ≡ lookup key empty
+      lemma key
+        rewrite prop-lookup-intersectionWith key empty ys f
+        rewrite prop-lookup-empty {k} {a} key
+        rewrite prop-lookup-empty {k} {c} key
+        = refl
+
+  -- | 'intersectionWith' an empty 'Map' yields again an empty 'Map'.
+  prop-intersectionWith-x-empty
+    : ∀ (f : a → b → c) (xs : Map k a)
+    → intersectionWith f xs (empty {k} {b}) ≡ empty
+  --
+  prop-intersectionWith-x-empty {a} {b} {c} f xs =
+      prop-equality lemma
+    where
+      lemma
+        : ∀ (key : k)
+        → lookup key (intersectionWith f xs (empty {k} {b}))
+          ≡ lookup key empty
+      lemma key
+        rewrite prop-lookup-intersectionWith key xs empty f
+        rewrite prop-lookup-empty {k} {b} key
+        rewrite prop-lookup-empty {k} {c} key
+        with lookup key xs
+      ... | Nothing = refl
+      ... | Just x  = refl
+
+  -- | 'intersectionWith' on singletons.
+  prop-intersectionWith-singleton
+    : ∀ ⦃ _ : IsLawfulEq k ⦄ (f : a → b → c) (keyx : k) (x : a) (keyy : k) (y : b)
+    → intersectionWith f (singleton keyx x) (singleton keyy y)
+      ≡ (if keyx == keyy then singleton keyx (f x y) else empty)
+  --
+  prop-intersectionWith-singleton {a} {b} {c} f keyx x keyy y =
+      prop-equality lemma
+    where
+      lemma
+        : ∀ (key : k)
+        → lookup key (intersectionWith f (singleton keyx x) (singleton keyy y))
+          ≡ lookup key (if keyx == keyy then singleton keyx (f x y) else empty)
+      lemma key
+        rewrite prop-lookup-intersectionWith key (singleton keyx x) (singleton keyy y) f
+        rewrite prop-lookup-singleton key keyx x
+        rewrite prop-lookup-singleton key keyy y
+        rewrite prop-if-apply (lookup key) (keyx == keyy) (singleton keyx (f x y)) empty
+        rewrite prop-lookup-singleton key keyx (f x y)
+        rewrite prop-lookup-empty {k} {c} key
+        rewrite eqSymmetry key keyx
+        with _ ← guard-eq-trans keyx key keyy
+        with keyx == key | key == keyy | keyx == keyy
+      ... | False | False | False = refl
+      ... | False | False | True  = refl
+      ... | False | True  | False = refl
+      ... | True  | False | False = refl
+      ... | True  | True  | True  = refl
+
+  -- | 'intersectionWith' distributes over 'unionWith' in the second argument
+  -- if the involved functions distribute over each other.
+  prop-intersectionWith-x-unionWith
+    : ∀ (f : a → b → c) (xs : Map k a) (g : b → b → b) (ys zs : Map k b)
+        (g' : c → c → c)
+    → (∀ x y z → f x (g y z) ≡ g' (f x y) (f x z))
+    → intersectionWith f xs (unionWith g ys zs)
+      ≡ unionWith g' (intersectionWith f xs ys) (intersectionWith f xs zs)
+  --
+  prop-intersectionWith-x-unionWith f xs g ys zs g' cond =
+      prop-equality lemma
+    where
+      lemma
+        : ∀ (key : k)
+        → lookup key (intersectionWith f xs (unionWith g ys zs))
+          ≡ lookup key (unionWith g' (intersectionWith f xs ys) (intersectionWith f xs zs))
+      lemma key
+        rewrite prop-lookup-intersectionWith key xs (unionWith g ys zs) f
+        rewrite prop-lookup-unionWith key g ys zs
+        rewrite prop-lookup-unionWith key g' (intersectionWith f xs ys) (intersectionWith f xs zs)
+        rewrite prop-lookup-intersectionWith key xs ys f
+        rewrite prop-lookup-intersectionWith key xs zs f
+        with lookup key xs
+      ... | Nothing = refl 
+      ... | Just x
+          with lookup key ys | lookup key zs
+      ...   | Nothing | Nothing = refl
+      ...   | Nothing | Just z  = refl
+      ...   | Just y  | Nothing = refl
+      ...   | Just y  | Just z  = cong Just (cond x y z)
+
+  -- | 'intersectionWith' distributes over 'unionWith' in the second argument
+  -- if the involved functions distribute over each other.
+  prop-intersectionWith-unionWith-x
+    : ∀ (f : a → b → c) (xs ys : Map k a) (g : a → a → a) (zs : Map k b)
+        (g' : c → c → c)
+    → (∀ x y z → f (g x y) z ≡ g' (f x z) (f y z))
+    → intersectionWith f (unionWith g xs ys) zs
+      ≡ unionWith g' (intersectionWith f xs zs) (intersectionWith f ys zs)
+  --
+  prop-intersectionWith-unionWith-x f xs ys g zs g' cond =
+      prop-equality lemma
+    where
+      lemma
+        : ∀ (key : k)
+        → lookup key (intersectionWith f (unionWith g xs ys) zs)
+          ≡ lookup key (unionWith g' (intersectionWith f xs zs) (intersectionWith f ys zs))
+      lemma key
+        rewrite prop-lookup-intersectionWith key (unionWith g xs ys) zs f
+        rewrite prop-lookup-unionWith key g xs ys
+        rewrite prop-lookup-unionWith key g' (intersectionWith f xs zs) (intersectionWith f ys zs)
+        rewrite prop-lookup-intersectionWith key xs zs f
+        rewrite prop-lookup-intersectionWith key ys zs f
+        with lookup key xs | lookup key ys | lookup key zs
+      ... | Nothing | Nothing | Nothing = refl 
+      ... | Nothing | Nothing | Just z  = refl 
+      ... | Nothing | Just y  | Nothing = refl 
+      ... | Nothing | Just y  | Just z  = refl 
+      ... | Just x  | Nothing | Nothing = refl 
+      ... | Just x  | Nothing | Just z  = refl 
+      ... | Just x  | Just y  | Nothing = refl 
+      ... | Just x  | Just y  | Just z  = cong Just (cond x y z) 

--- a/lib/bags/agda/bags.agda
+++ b/lib/bags/agda/bags.agda
@@ -12,3 +12,5 @@ import Data.Monoid.Morphism
 import Data.Monoid.Refinement
 
 import Data.Bag
+
+import Data.BagOld -- to be absorbed

--- a/lib/bags/agda/bags.agda
+++ b/lib/bags/agda/bags.agda
@@ -12,5 +12,6 @@ import Data.Monoid.Morphism
 import Data.Monoid.Refinement
 
 import Data.Bag
+import Data.Indexed
 
 import Data.BagOld -- to be absorbed


### PR DESCRIPTION
This pull request `postulate`s the `Bag` data type as a free commutative monoid.

We also add the data type `Table k` from the paper, and the `indexBy` operation to obtain an efficient index.