### PR TITLE
nix: Implement `mkDerivation` that uses `agda2hs` instead of `agda`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -15,14 +15,18 @@
         # ###########################################
         # Imports
 
-        pkgs = import nixpkgs {inherit system;};
+        pkgs = import nixpkgs { inherit system; };
+        lib  = import ./nix/lib.nix {
+          inherit pkgs;
+          agda2hs-lib = agda2hs.lib.${system};
+        };
         
         # ###########################################
         # Helpers
 
         # TODO: Specific Haskell compiler
 
-        base-lib = pkgs.agdaPackages.mkDerivation {
+        base-lib = lib.mkDerivation {
           pname = "base";
           meta = {};
           version = "4.18";
@@ -41,7 +45,7 @@
             cd lib/base
           '';
         };
-        containers-lib = pkgs.agdaPackages.mkDerivation {
+        containers-lib = lib.mkDerivation {
           pname = "containers";
           meta = { };
           version = "0.8";
@@ -59,7 +63,7 @@
         };
 
         agda2hs-custom = agda2hs.lib.${system}.withPackages ([
-          agda2hs.packages.${system}.base-lib
+          base-lib
           containers-lib
         ]);
 

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -1,0 +1,55 @@
+# Build helpers for Agda2hs libraries
+
+{
+  pkgs,
+  agda2hs-lib,
+}:
+let
+  # Imports
+  inherit (pkgs.lib)
+    filter
+    ;
+  inherit (pkgs.lib.strings)
+    concatMapStrings
+    ;
+
+  # Definitions
+  completeArgs =
+    {
+      pname,
+      meta,
+      buildInputs ? [ ],
+      everythingFile ? "./Everything.agda",
+      includePaths ? [ ],
+      libraryName ? pname,
+      libraryFile ? "${libraryName}.agda-lib",
+      buildPhase ? null,
+      installPhase ? null,
+      extraExtensions ? [ ],
+      ...
+    } :
+    let
+      withPackages = agda2hs-lib.withPackages;
+      agda2hsWithArgs = withPackages (filter (p: p ? isAgda2HsDerivation) buildInputs);
+      includePathArgs = concatMapStrings (path: "-i" + path + " ") (
+        includePaths ++ [ (dirOf everythingFile) ]
+      );
+    in
+    {
+      isAgda2HsDerivation = true;
+
+      buildInputs = buildInputs ++ [ agda2hsWithArgs ];
+
+      buildPhase = 
+        ''
+        runHook preBuild
+        agda2hs ${includePathArgs} ${everythingFile}
+        rm ${everythingFile} "${everythingFile}i"
+        runHook postBuild
+        '';
+    };
+in
+{
+  mkDerivation = args:
+    pkgs.agdaPackages.mkDerivation (args // completeArgs args);
+}


### PR DESCRIPTION
This pull request implements a `mkDerivation` that uses `agda2hs` instead of `agda`. The `mkDerivation` function is used to provide agda2hs libraries.

It's necessary to use `agda2hs` instead of `Agda` to compile `.agda-lib` libraries, otherwise the result is not quite compatible with `agda2hs`, especially when having transitive dependencies.

This is required to make the `containers.agda-lib` work in Nix.