### PR TITLE
Implement 'Bag' as an abstract data type

### DIFF
--- a/lib/bags/agda/Data/Bag.agda
+++ b/lib/bags/agda/Data/Bag.agda
@@ -1,5 +1,5 @@
 module Data.Bag where
 
-open import Data.Bag.Def  public
-open import Data.Bag.Core public
-open import Data.Bag.Prop public
+open import Haskell.Data.Bag        public
+open import Data.Bag.Quotient.Prop  public
+open import Data.Bag.Prop           public

--- a/lib/bags/agda/Data/Bag/Prop.agda
+++ b/lib/bags/agda/Data/Bag/Prop.agda
@@ -4,7 +4,7 @@ module Data.Bag.Prop where
 
 open import Haskell.Prelude hiding (lookup; null; map; filter)
 
-open import Data.Bag.Core
+open import Data.Bag.Quotient.Prop
 open import Data.Bag.Def
 
 open import Haskell.Prim.Alternative

--- a/lib/bags/agda/Data/Bag/Quotient/Prop.agda
+++ b/lib/bags/agda/Data/Bag/Quotient/Prop.agda
@@ -1,84 +1,18 @@
-{-# OPTIONS --confluence-check #-}
 
--- | Core axiomatization of 'Bag' as the free commutative monoid.
-module Data.Bag.Core where
+-- | Core properties of 'Bag'
+module Data.Bag.Quotient.Prop where
 
-open import Agda.Builtin.Equality.Rewrite
+open import Haskell.Prelude
 
-open import Haskell.Prim
-open import Haskell.Prim.Monoid
 open import Haskell.Law
 open import Haskell.Law.Extensionality using (ext)
 open import Haskell.Law.Function
-open import Haskell.Law.Monoid
 open import Haskell.Law.Monoid as Monoid
 
 import Data.Monoid.Refinement as Monoid
 import Data.Monoid.Morphism as Monoid
 
-{-----------------------------------------------------------------------------
-    Type Definition
-------------------------------------------------------------------------------}
-postulate
-  Bag : Type → Type
-
-  singleton : a → Bag a
-
-  -- Bags are a monoid.
-  instance
-    iMonoidBag : Monoid (Bag a)
-
-instance
-  iSemigroupBag : Semigroup (Bag a)
-  iSemigroupBag = iMonoidBag .Monoid.super
-
-postulate
-  instance
-    iLawfulMonoidBag : IsLawfulMonoid (Bag a)
-
-  -- Bags are a commutative monoid.
-  prop-<>-sym : Commutative (_<>_ {Bag a})
-
-  -- Universal property, existence:
-  -- Any map to a commutative monoid factors through 'Bag'
-  foldBag
-    : ∀ ⦃ _ : Monoid.Commutative b ⦄
-    → (a → b) → (Bag a → b)
-
-  prop-foldBag-singleton
-    : ∀ ⦃ _ : Monoid.Commutative b ⦄ (f : a → b) (x : a)
-    → foldBag f (singleton x) ≡ f x
-
-  prop-foldBag-mempty
-    : ∀ ⦃ _ : Monoid.Commutative b ⦄ (f : a → b)
-    → foldBag f mempty ≡ mempty
-
-  prop-foldBag-<>
-    : ∀ ⦃ _ : Monoid.Commutative b ⦄ (f : a → b) (xs ys : Bag a)
-    → foldBag f (xs <> ys) ≡ foldBag f xs <> foldBag f ys
-
-  -- Universal property, uniqueness
-  prop-foldBag-unique
-    : ∀ ⦃ _ : Monoid.Commutative b ⦄ (g : Bag a → b)
-    → @0 Monoid.IsHomomorphism g
-    → ∀ (xs : Bag a) → foldBag (g ∘ singleton) xs ≡ g xs
-
-instance
-  iLawfulSemigroupBag : IsLawfulSemigroup (Bag a)
-  iLawfulSemigroupBag = iLawfulMonoidBag .super
-
-  iMonoidCommutativeBag : Monoid.Commutative (Bag a)
-  iMonoidCommutativeBag .Monoid.monoid = iMonoidBag
-  iMonoidCommutativeBag .Monoid.commutative = prop-<>-sym
-
-{- [Rewrite foldBag]
-
-In order to make the 'Bag' quotient type easy to use,
-we introduce rewrite rules that allow us to compute 'foldBag'.
--}
-{-# REWRITE prop-foldBag-singleton #-}
-{-# REWRITE prop-foldBag-mempty #-}
-{-# REWRITE prop-foldBag-<> #-}
+open import Haskell.Data.Bag.Quotient public
 
 {-----------------------------------------------------------------------------
     Core properties

--- a/lib/bags/agda/Data/Bag/Raw.agda
+++ b/lib/bags/agda/Data/Bag/Raw.agda
@@ -1,0 +1,34 @@
+-- | Type and operations, before taking the quotient.
+module Data.Bag.Raw where
+
+open import Haskell.Prelude
+
+{-----------------------------------------------------------------------------
+    Type
+------------------------------------------------------------------------------}
+data Bag a : Type where
+  Single : a → Bag a
+  Empty  : Bag a
+  Union  : Bag a → Bag a → Bag a
+
+singleton : a → Bag a
+singleton = Single
+
+empty : Bag a
+empty = Empty
+
+union : Bag a → Bag a → Bag a
+union Empty ys = ys
+union xs Empty = xs
+union xs ys    = Union xs ys
+
+foldBag : ⦃ _ : Monoid b ⦄ → (a → b) → Bag a → b
+foldBag _ Empty         = mempty
+foldBag f (Single x)    = f x
+foldBag f (Union xs ys) = foldBag f xs <> foldBag f ys
+
+{-# COMPILE AGDA2HS Bag #-}
+{-# COMPILE AGDA2HS singleton #-}
+{-# COMPILE AGDA2HS empty #-}
+{-# COMPILE AGDA2HS union #-}
+{-# COMPILE AGDA2HS foldBag #-}

--- a/lib/bags/agda/Haskell/Data/Bag.agda
+++ b/lib/bags/agda/Haskell/Data/Bag.agda
@@ -1,0 +1,4 @@
+module Haskell.Data.Bag where
+
+open import Haskell.Data.Bag.Quotient public
+open import Data.Bag.Def              public

--- a/lib/bags/agda/Haskell/Data/Bag/Quotient.agda
+++ b/lib/bags/agda/Haskell/Data/Bag/Quotient.agda
@@ -1,0 +1,92 @@
+-- | Type and operations, after taking the quotient.
+--
+-- * We use an export list in Haskell to make the type abstract.
+-- * We do not prove that the operations preserve the equivalence
+--   — we only postulate this fact here.
+--
+module Haskell.Data.Bag.Quotient where
+
+open import Agda.Builtin.Equality.Rewrite
+
+open import Haskell.Prelude
+
+open import Haskell.Law.Eq
+open import Haskell.Law.Equality
+open import Haskell.Law.Extensionality
+open import Haskell.Law.Function
+open import Haskell.Law.Monoid
+
+import Data.Monoid.Morphism as Monoid
+import Data.Monoid.Refinement as Monoid
+
+{-----------------------------------------------------------------------------
+    Type and Operations
+------------------------------------------------------------------------------}
+postulate
+  Bag : Type → Type
+
+  singleton : a → Bag a
+
+  -- Bags are a monoid.
+  instance
+    iMonoidBag : Monoid (Bag a)
+
+  -- Any map to a commutative monoid factors through 'Bag'
+  foldBag
+    : ∀ ⦃ _ : Monoid.Commutative b ⦄
+    → (a → b) → (Bag a → b)
+
+instance
+  iSemigroupBag : Semigroup (Bag a)
+  iSemigroupBag = iMonoidBag .Monoid.super
+
+{-----------------------------------------------------------------------------
+    Properties
+------------------------------------------------------------------------------}
+postulate
+  instance
+    iLawfulMonoidBag : IsLawfulMonoid (Bag a)
+
+  -- Bags are a commutative monoid.
+  prop-<>-sym : Commutative (_<>_ {Bag a})
+
+  -- Universal properties of 'foldBag'
+  -- 'f' factors through 'singleton'.
+  prop-foldBag-singleton
+    : ∀ ⦃ _ : Monoid.Commutative b ⦄ (f : a → b) (x : a)
+    → foldBag f (singleton x) ≡ f x
+
+  -- Universal property, 'foldBag' is a homomorphism.
+  prop-foldBag-mempty
+    : ∀ ⦃ _ : Monoid.Commutative b ⦄ (f : a → b)
+    → foldBag f mempty ≡ mempty
+
+  prop-foldBag-<>
+    : ∀ ⦃ _ : Monoid.Commutative b ⦄ (f : a → b) (xs ys : Bag a)
+    → foldBag f (xs <> ys) ≡ foldBag f xs <> foldBag f ys
+
+  -- Universal property, uniqueness
+  prop-foldBag-unique
+    : ∀ ⦃ _ : Monoid.Commutative b ⦄ (g : Bag a → b)
+    → @0 Monoid.IsHomomorphism g
+    → ∀ (xs : Bag a) → foldBag (g ∘ singleton) xs ≡ g xs
+
+instance
+  iLawfulSemigroupBag : IsLawfulSemigroup (Bag a)
+  iLawfulSemigroupBag = iLawfulMonoidBag .super
+
+  iMonoidCommutativeBag : Monoid.Commutative (Bag a)
+  iMonoidCommutativeBag .Monoid.monoid = iMonoidBag
+  iMonoidCommutativeBag .Monoid.commutative = prop-<>-sym
+
+{-----------------------------------------------------------------------------
+    Rewrite Rules
+------------------------------------------------------------------------------}
+{- [Rewrite foldBag]
+
+In order to make the 'Bag' quotient type easy to use,
+we introduce rewrite rules that allow us to compute 'foldBag'.
+-}
+{-# REWRITE prop-foldBag-singleton #-}
+{-# REWRITE prop-foldBag-mempty #-}
+{-# REWRITE prop-foldBag-<> #-}

--- a/lib/bags/agda/bags.agda
+++ b/lib/bags/agda/bags.agda
@@ -12,6 +12,8 @@ import Data.Monoid.Morphism
 import Data.Monoid.Refinement
 
 import Data.Bag
+import Data.Bag.Raw
+
 import Data.Indexed
 
 import Data.BagOld -- to be absorbed

--- a/lib/bags/agda2hs-rewrites.yaml
+++ b/lib/bags/agda2hs-rewrites.yaml
@@ -1,0 +1,7 @@
+prelude:
+  implicit: true
+  hiding:
+    - "null"
+    - "filter"
+    - "map"
+    - "concatMap"

--- a/lib/bags/bags.cabal
+++ b/lib/bags/bags.cabal
@@ -66,5 +66,14 @@ library
     , base        >=4.14 && <5
     , containers  >=0.5  && <0.8
 
-  exposed-modules: Data.Bag
-  autogen-modules: Data.Bag
+  exposed-modules:
+    Data.Bag
+    Data.Monoid.Refinement
+  other-modules:
+    Data.Bag.Def
+    Data.Bag.Quotient
+    Data.Bag.Raw
+  autogen-modules:
+    Data.Bag.Def
+    Data.Bag.Raw
+    Data.Monoid.Refinement

--- a/lib/bags/generate-haskell.sh
+++ b/lib/bags/generate-haskell.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 ROOT=bags.agda 
 agda2hs \
+    --config agda2hs-rewrites.yaml \
     -o ./haskell/ \
     ./agda/${ROOT}

--- a/lib/bags/haskell/Data/Bag.hs
+++ b/lib/bags/haskell/Data/Bag.hs
@@ -1,0 +1,9 @@
+module Data.Bag
+    ( -- * Definition
+      module Data.Bag.Quotient
+    -- * Operations
+    , module Data.Bag.Def
+    ) where
+
+import Data.Bag.Def
+import Data.Bag.Quotient

--- a/lib/bags/haskell/Data/Bag/Def.hs
+++ b/lib/bags/haskell/Data/Bag/Def.hs
@@ -1,0 +1,67 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Data.Bag.Def where
+
+import Prelude hiding (null, filter, map, concatMap)
+import Data.Bag.Quotient (Bag, foldBag, singleton)
+
+
+
+import Control.Monad (guard, MonadPlus)
+import Control.Applicative (Alternative (..))
+
+union :: Bag a -> Bag a -> Bag a
+union = (<>)
+
+fromMaybe :: Maybe a -> Bag a
+fromMaybe Nothing = mempty
+fromMaybe (Just x) = singleton x
+
+concatMap :: (a -> Bag b) -> Bag a -> Bag b
+concatMap = foldBag
+
+map :: (a -> b) -> Bag a -> Bag b
+map f = concatMap (singleton . f)
+
+fromList :: [a] -> Bag a
+fromList = foldMap singleton
+
+instance Functor Bag where
+    fmap = map
+
+instance Monad Bag where
+    (>>=) = flip concatMap
+
+instance Alternative Bag where
+    empty = mempty
+    (<|>) = (<>)
+
+-- Workaround instance for issue in Agda2hs.
+-- Issue: Definitions of `pure` and `<*>` are duplicated for some reason.
+instance Applicative Bag where
+  pure = singleton
+  fs <*> xs = concatMap (\ f -> map f xs) fs
+
+-- Workaround instance for issue in Agda2hs
+instance MonadPlus Bag
+
+filter :: (a -> Bool) -> Bag a -> Bag a
+filter p xs
+  = do x <- xs
+       guard (p x)
+       pure x
+
+cartesianProduct :: Bag a -> Bag b -> Bag (a, b)
+cartesianProduct xs ys
+  = do x <- xs
+       y <- ys
+       pure (x, y)
+
+equijoin ::
+           Eq k => (a -> k) -> (b -> k) -> Bag a -> Bag b -> Bag (a, b)
+equijoin f g xs ys
+  = do x <- xs
+       y <- ys
+       guard (f x == g y)
+       pure (x, y)
+

--- a/lib/bags/haskell/Data/Bag/Quotient.hs
+++ b/lib/bags/haskell/Data/Bag/Quotient.hs
@@ -1,0 +1,40 @@
+module Data.Bag.Quotient
+    ( Bag
+    , singleton
+    , foldBag
+    ) where
+
+import qualified Data.Bag.Raw as Raw
+
+import qualified Data.Monoid.Refinement as Monoid
+
+-- | A 'Bag'@ a@ is a collection of items of type @a@.
+-- Items may appear multiple times.
+-- The order of items does __not__ matter.
+--
+-- Put differently,
+-- 'Bag'@ a@ is the free commutative monoid on items of type @a@.
+newtype Bag a = Bag (Raw.Bag a)
+
+-- | '(<>)' is the union of two 'Bag's.
+instance Semigroup (Bag a) where
+    (Bag xs) <> (Bag ys) = Bag (Raw.union xs ys)
+
+-- | 'mempty' is the empty 'Bag'.
+instance Monoid (Bag a) where
+    mempty = Bag Raw.empty
+
+-- | The union of two 'Bag's is commutative.
+instance Monoid.Commutative (Bag a)
+
+-- | 'Bag' containing a single item.
+singleton :: a -> Bag a
+singleton = Bag . Raw.singleton
+
+-- | Map all items from a 'Bag' to another commutative monoid,
+-- and combine the results.
+--
+-- Put differently,
+-- 'foldBag' is the universal map from 'Bag' to any other commutative monoid.
+foldBag :: Monoid.Commutative b => (a -> b) -> Bag a -> b
+foldBag f (Bag xs) = Raw.foldBag f xs

--- a/lib/bags/haskell/Data/Bag/Raw.hs
+++ b/lib/bags/haskell/Data/Bag/Raw.hs
@@ -1,0 +1,24 @@
+module Data.Bag.Raw where
+
+import Prelude hiding (null, filter, map, concatMap)
+
+data Bag a = Single a
+           | Empty
+           | Union (Bag a) (Bag a)
+
+singleton :: a -> Bag a
+singleton = Single
+
+empty :: Bag a
+empty = Empty
+
+union :: Bag a -> Bag a -> Bag a
+union Empty ys = ys
+union xs Empty = xs
+union xs ys = Union xs ys
+
+foldBag :: Monoid b => (a -> b) -> Bag a -> b
+foldBag _ Empty = mempty
+foldBag f (Single x) = f x
+foldBag f (Union xs ys) = foldBag f xs <> foldBag f ys
+

--- a/lib/bags/haskell/Data/Monoid/Refinement.hs
+++ b/lib/bags/haskell/Data/Monoid/Refinement.hs
@@ -1,0 +1,15 @@
+module Data.Monoid.Refinement where
+
+import Prelude hiding (null, filter, map, concatMap)
+
+class Monoid a => Commutative a where
+
+instance Commutative () where
+
+instance (Commutative a, Commutative b) => Commutative ((a, b))
+         where
+
+instance (Commutative a, Commutative b, Commutative c) =>
+         Commutative ((a, b, c))
+         where
+


### PR DESCRIPTION
This pull request implements `Bag` as an abstract data type in Haskell, and postulates the core properties.

This could be implementation in terms of a general `Quotient` type in Adga. However, we would have to prove that e.g. `union` preserves equivalence classes of `Raw.Bag`. A first attempt at doing so gave me the impression that this is more tricky than anticipated, so I have postponed the proofs here via `postulate`.