### PR TITLE
Use types with specialized `Monoid` instances

### DIFF
--- a/lib/bags/agda/Data/Bag/Def.agda
+++ b/lib/bags/agda/Data/Bag/Def.agda
@@ -23,7 +23,8 @@ open import Haskell.Law.Function
 open import Haskell.Law.Num
 
 open import Haskell.Data.Bag.Quotient
-import Data.Monoid.Refinement as Monoid
+open import Data.Monoid.Extra
+import      Data.Monoid.Refinement as Monoid
 
 {-# FOREIGN AGDA2HS
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -37,11 +38,17 @@ import Control.Applicative (Alternative (..))
     Operations
     basic
 ------------------------------------------------------------------------------}
+-- | Test whether the 'Bag' is empty, 'Monoid' version.
+mnull : Bag a → Conj
+mnull = foldBag (λ _ → MkConj False)
+
+{-# COMPILE AGDA2HS mnull #-}
+
 -- | Test whether the 'Bag' is empty.
 null : Bag a → Bool
-null = foldBag {{Monoid.CommutativeConj}} (λ _ → False)
+null = getConj ∘ mnull
 
--- {-# COMPILE AGDA2HS null #-}
+{-# COMPILE AGDA2HS null #-}
 
 -- | Union of all items from the two arguments.
 -- Synonym for '(<>)'.

--- a/lib/bags/agda/Data/Bag/Def.agda
+++ b/lib/bags/agda/Data/Bag/Def.agda
@@ -64,11 +64,17 @@ fromMaybe (Just x) = singleton x
 
 {-# COMPILE AGDA2HS fromMaybe #-}
 
+-- | Number of items in the Bag, Monoid version
+msize : Bag a → Sum' Int
+msize = foldBag (λ _ → MkSum 1)
+
+{-# COMPILE AGDA2HS msize #-}
+
 -- | Number of items in the Bag.
 size : Bag a → Int
-size = foldBag {{Monoid.CommutativeSum}} (λ _ → 1)
+size = getSum' ∘ msize
 
--- {-# COMPILE AGDA2HS size #-}
+{-# COMPILE AGDA2HS size #-}
 
 -- | Apply a function to all elements in the 'Bag'
 -- and take the union of the results.
@@ -152,13 +158,13 @@ filter p xs = do x ← xs; guard (p x); pure x
 count : ⦃ Eq a ⦄ → a → Bag a → Int
 count x = size ∘ filter (x ==_)
 
--- {-# COMPILE AGDA2HS count #-}
+{-# COMPILE AGDA2HS count #-}
 
 -- | Check whether an item is contained in the 'Bag' at least once.
 member : ⦃ Eq a ⦄ → a → Bag a → Bool
 member x ys = 0 < count x ys
 
--- {-# COMPILE AGDA2HS member #-}
+{-# COMPILE AGDA2HS member #-}
 
 -- | 'Bag' containing all possible pairs of items.
 cartesianProduct : Bag a → Bag b → Bag (a × b)

--- a/lib/bags/agda/Data/Bag/Prop.agda
+++ b/lib/bags/agda/Data/Bag/Prop.agda
@@ -179,10 +179,10 @@ prop-fromList-filter p (x ∷ xs)
     Homomorphisms
 ------------------------------------------------------------------------------}
 -- | 'size' is a monoid homomorphism.
-prop-morphism-size
-  : Monoid.IsHomomorphism ⦃ iMonoidBag {a} ⦄ ⦃ MonoidSum ⦄ size
+prop-morphism-msize
+  : Monoid.IsHomomorphism ⦃ iMonoidBag {a} ⦄ msize
 --
-prop-morphism-size = prop-morphism-foldBag ⦃ Monoid.CommutativeSum ⦄ _
+prop-morphism-msize = prop-morphism-foldBag _
 
 -- | 'fromList' is a monoid homomorphism.
 prop-morphism-fromList

--- a/lib/bags/agda/Data/Monoid/Extra.agda
+++ b/lib/bags/agda/Data/Monoid/Extra.agda
@@ -24,3 +24,26 @@ instance
 
 {-# COMPILE AGDA2HS iSemigroupConj #-}
 {-# COMPILE AGDA2HS iMonoidConj #-}
+
+-- Monoid under addition.
+record Sum' a : Type where
+  constructor MkSum
+  field
+    getSum' : a
+
+open Sum' public
+
+{-# COMPILE AGDA2HS Sum' newtype #-}
+
+instance
+  iSemigroupSum' : ⦃ Num a ⦄ → Semigroup (Sum' a)
+  iSemigroupSum' ._<>_ x y = record{getSum' = getSum' x + getSum' y}
+
+  iDefaultMonoidSum' : ⦃ Num a ⦄ → DefaultMonoid (Sum' a)
+  iDefaultMonoidSum' .DefaultMonoid.mempty = record{getSum' = 0}
+
+  iMonoidSum' : ⦃ Num a ⦄ → Monoid (Sum' a)
+  iMonoidSum' = record{DefaultMonoid iDefaultMonoidSum'}
+
+{-# COMPILE AGDA2HS iSemigroupSum' #-}
+{-# COMPILE AGDA2HS iMonoidSum' #-}

--- a/lib/bags/agda/Data/Monoid/Extra.agda
+++ b/lib/bags/agda/Data/Monoid/Extra.agda
@@ -1,0 +1,26 @@
+module Data.Monoid.Extra where
+
+open import Haskell.Prelude
+
+-- Boolean monoid under conjunction '(&&)'.
+record Conj : Type where
+  constructor MkConj
+  field
+    getConj : Bool
+
+open Conj public
+
+{-# COMPILE AGDA2HS Conj newtype #-}
+
+instance
+  iSemigroupConj : Semigroup Conj
+  iSemigroupConj ._<>_ x y = record{getConj = getConj x && getConj y}
+
+  iDefaultMonoidConj : DefaultMonoid Conj
+  iDefaultMonoidConj .DefaultMonoid.mempty = record{getConj = True}
+
+  iMonoidConj : Monoid Conj
+  iMonoidConj = record{DefaultMonoid iDefaultMonoidConj}
+
+{-# COMPILE AGDA2HS iSemigroupConj #-}
+{-# COMPILE AGDA2HS iMonoidConj #-}

--- a/lib/bags/agda/Data/Monoid/Refinement.agda
+++ b/lib/bags/agda/Data/Monoid/Refinement.agda
@@ -71,14 +71,6 @@ CommutativeSum : ⦃ _ : Num a ⦄ → ⦃ IsLawfulNum a ⦄ → Commutative a
 CommutativeSum .monoid = MonoidSum
 CommutativeSum .commutative = +-comm
 
-CommutativeConj : Commutative Bool
-CommutativeConj .monoid = MonoidConj
-CommutativeConj .commutative = prop-&&-sym
-
-CommutativeDisj : Commutative Bool
-CommutativeDisj .monoid = MonoidDisj
-CommutativeDisj .commutative = prop-||-sym
-
 {- *-comm is not part of IsLawfulNum yet?!
 
 CommutativeProduct : ⦃ _ : Num a ⦄ → ⦃ _ : IsLawfulNum a ⦄ → Commutative a

--- a/lib/bags/agda/Data/Monoid/Refinement.agda
+++ b/lib/bags/agda/Data/Monoid/Refinement.agda
@@ -62,10 +62,16 @@ instance
   iCommutativeConj .commutative record{getConj = x} record{getConj = y}
     = cong (λ o → record{getConj = o}) (prop-&&-sym x y)
 
+  iCommutativeSum' : ⦃ _ : Num a ⦄ → @0 ⦃ IsLawfulNum a ⦄ → Commutative (Sum' a)
+  iCommutativeSum' .monoid = iMonoidSum'
+  iCommutativeSum' .commutative record{getSum' = x} record{getSum' = y}
+    = cong (λ o → record { getSum' = o }) (+-comm x y)
+
 {-# COMPILE AGDA2HS iCommutativeUnit #-}
 {-# COMPILE AGDA2HS iCommutativeTuple₂ #-}
 {-# COMPILE AGDA2HS iCommutativeTuple₃ #-}
 {-# COMPILE AGDA2HS iCommutativeConj #-}
+{-# COMPILE AGDA2HS iCommutativeSum' #-}
 
 CommutativeSum : ⦃ _ : Num a ⦄ → ⦃ IsLawfulNum a ⦄ → Commutative a
 CommutativeSum .monoid = MonoidSum

--- a/lib/bags/agda/Data/Monoid/Refinement.agda
+++ b/lib/bags/agda/Data/Monoid/Refinement.agda
@@ -73,10 +73,6 @@ instance
 {-# COMPILE AGDA2HS iCommutativeConj #-}
 {-# COMPILE AGDA2HS iCommutativeSum' #-}
 
-CommutativeSum : ⦃ _ : Num a ⦄ → ⦃ IsLawfulNum a ⦄ → Commutative a
-CommutativeSum .monoid = MonoidSum
-CommutativeSum .commutative = +-comm
-
 {- *-comm is not part of IsLawfulNum yet?!
 
 CommutativeProduct : ⦃ _ : Num a ⦄ → ⦃ _ : IsLawfulNum a ⦄ → Commutative a

--- a/lib/bags/agda/Data/Monoid/Refinement.agda
+++ b/lib/bags/agda/Data/Monoid/Refinement.agda
@@ -12,6 +12,8 @@ open import Haskell.Law
 open import Haskell.Law.Extensionality
 open import Haskell.Law.Num
 
+open import Data.Monoid.Extra
+
 -------------------------------------------------------------------------------
 -- Commutative monoids
 
@@ -55,9 +57,15 @@ instance
     rewrite commutative x3 y3
     = refl
 
+  iCommutativeConj : Commutative Conj
+  iCommutativeConj .monoid = iMonoidConj
+  iCommutativeConj .commutative record{getConj = x} record{getConj = y}
+    = cong (λ o → record{getConj = o}) (prop-&&-sym x y)
+
 {-# COMPILE AGDA2HS iCommutativeUnit #-}
 {-# COMPILE AGDA2HS iCommutativeTuple₂ #-}
 {-# COMPILE AGDA2HS iCommutativeTuple₃ #-}
+{-# COMPILE AGDA2HS iCommutativeConj #-}
 
 CommutativeSum : ⦃ _ : Num a ⦄ → ⦃ IsLawfulNum a ⦄ → Commutative a
 CommutativeSum .monoid = MonoidSum

--- a/lib/bags/bags.cabal
+++ b/lib/bags/bags.cabal
@@ -68,6 +68,7 @@ library
 
   exposed-modules:
     Data.Bag
+    Data.Monoid.Extra
     Data.Monoid.Refinement
   other-modules:
     Data.Bag.Def

--- a/lib/bags/haskell/Data/Bag/Def.hs
+++ b/lib/bags/haskell/Data/Bag/Def.hs
@@ -4,7 +4,7 @@ module Data.Bag.Def where
 
 import Prelude hiding (null, filter, map, concatMap)
 import Data.Bag.Quotient (Bag, foldBag, singleton)
-import Data.Monoid.Extra (Conj(MkConj, getConj))
+import Data.Monoid.Extra (Conj(MkConj, getConj), Sum'(MkSum, getSum'))
 import Data.Monoid.Refinement ()
 
 
@@ -24,6 +24,12 @@ union = (<>)
 fromMaybe :: Maybe a -> Bag a
 fromMaybe Nothing = mempty
 fromMaybe (Just x) = singleton x
+
+msize :: Bag a -> Sum' Int
+msize = foldBag (\ _ -> MkSum 1)
+
+size :: Bag a -> Int
+size = (\ r -> getSum' r) . msize
 
 concatMap :: (a -> Bag b) -> Bag a -> Bag b
 concatMap = foldBag
@@ -58,6 +64,12 @@ filter p xs
   = do x <- xs
        guard (p x)
        pure x
+
+count :: Eq a => a -> Bag a -> Int
+count x = size . filter (x ==)
+
+member :: Eq a => a -> Bag a -> Bool
+member x ys = 0 < count x ys
 
 cartesianProduct :: Bag a -> Bag b -> Bag (a, b)
 cartesianProduct xs ys

--- a/lib/bags/haskell/Data/Bag/Def.hs
+++ b/lib/bags/haskell/Data/Bag/Def.hs
@@ -4,11 +4,19 @@ module Data.Bag.Def where
 
 import Prelude hiding (null, filter, map, concatMap)
 import Data.Bag.Quotient (Bag, foldBag, singleton)
+import Data.Monoid.Extra (Conj(MkConj, getConj))
+import Data.Monoid.Refinement ()
 
 
 
 import Control.Monad (guard, MonadPlus)
 import Control.Applicative (Alternative (..))
+
+mnull :: Bag a -> Conj
+mnull = foldBag (\ _ -> MkConj False)
+
+null :: Bag a -> Bool
+null = (\ r -> getConj r) . mnull
 
 union :: Bag a -> Bag a -> Bag a
 union = (<>)

--- a/lib/bags/haskell/Data/Monoid/Extra.hs
+++ b/lib/bags/haskell/Data/Monoid/Extra.hs
@@ -10,3 +10,11 @@ instance Semigroup Conj where
 instance Monoid Conj where
     mempty = MkConj True
 
+newtype Sum' a = MkSum{getSum' :: a}
+
+instance (Num a) => Semigroup (Sum' a) where
+    x <> y = MkSum (getSum' x + getSum' y)
+
+instance (Num a) => Monoid (Sum' a) where
+    mempty = MkSum 0
+

--- a/lib/bags/haskell/Data/Monoid/Extra.hs
+++ b/lib/bags/haskell/Data/Monoid/Extra.hs
@@ -1,0 +1,12 @@
+module Data.Monoid.Extra where
+
+import Prelude hiding (null, filter, map, concatMap)
+
+newtype Conj = MkConj{getConj :: Bool}
+
+instance Semigroup Conj where
+    x <> y = MkConj (getConj x && getConj y)
+
+instance Monoid Conj where
+    mempty = MkConj True
+

--- a/lib/bags/haskell/Data/Monoid/Refinement.hs
+++ b/lib/bags/haskell/Data/Monoid/Refinement.hs
@@ -1,7 +1,7 @@
 module Data.Monoid.Refinement where
 
 import Prelude hiding (null, filter, map, concatMap)
-import Data.Monoid.Extra (Conj)
+import Data.Monoid.Extra (Conj, Sum')
 
 class Monoid a => Commutative a where
 
@@ -15,4 +15,6 @@ instance (Commutative a, Commutative b, Commutative c) =>
          where
 
 instance Commutative Conj where
+
+instance (Num a) => Commutative (Sum' a) where
 

--- a/lib/bags/haskell/Data/Monoid/Refinement.hs
+++ b/lib/bags/haskell/Data/Monoid/Refinement.hs
@@ -1,6 +1,7 @@
 module Data.Monoid.Refinement where
 
 import Prelude hiding (null, filter, map, concatMap)
+import Data.Monoid.Extra (Conj)
 
 class Monoid a => Commutative a where
 
@@ -12,4 +13,6 @@ instance (Commutative a, Commutative b) => Commutative ((a, b))
 instance (Commutative a, Commutative b, Commutative c) =>
          Commutative ((a, b, c))
          where
+
+instance Commutative Conj where
 


### PR DESCRIPTION
This pull request changes `null` and `size` to be defined in terms of functions `mnull` and `msize` whose result types are instances of `Monoid`.

In contrast, the return types `Bool` and `Int` support several distinct monoid operations. The definition in terms of `foldBag` requires choosing an instance locally, but this is not supported in Haskell.

Due to technical issues, the result types are added in `Data.Monoid.Extra`, even though using `All` and `Sum` from the `Data.Monoid` module would be nicer.