### PR TITLE
Add indexed tables, `Data.Table`

### DIFF
--- a/lib/bags/agda/Data/Indexed.agda
+++ b/lib/bags/agda/Data/Indexed.agda
@@ -1,4 +1,0 @@
-module Data.Indexed where
-
-open import Data.Indexed.Def  public
-open import Data.Indexed.Prop public

--- a/lib/bags/agda/Data/Table.agda
+++ b/lib/bags/agda/Data/Table.agda
@@ -1,0 +1,4 @@
+module Data.Table where
+
+open import Data.Table.Def  public
+open import Data.Table.Prop public

--- a/lib/bags/agda/Data/Table/Prop.agda
+++ b/lib/bags/agda/Data/Table/Prop.agda
@@ -1,10 +1,10 @@
 
 -- | Proofs about indexed 'Table's.
-module Data.Indexed.Prop where
+module Data.Table.Prop where
 
 open import Haskell.Prelude hiding (filter; lookup; null)
 
-open import Data.Indexed.Def
+open import Data.Table.Def
 
 open import Data.Bag using (Bag)
 import Data.Bag as Bag

--- a/lib/bags/agda/bags.agda
+++ b/lib/bags/agda/bags.agda
@@ -14,6 +14,6 @@ import Data.Monoid.Refinement
 import Data.Bag
 import Data.Bag.Raw
 
-import Data.Indexed
+import Data.Table
 
 import Data.BagOld -- to be absorbed

--- a/lib/bags/bags.cabal
+++ b/lib/bags/bags.cabal
@@ -41,14 +41,14 @@ common language
   default-language: Haskell2010
 
 common opts-exe
-  ghc-options: -threaded -rtsopts -Wall -Wredundant-constraints
+  ghc-options: -threaded -rtsopts -Wall -Wno-redundant-constraints
 
   if flag(release)
     ghc-options: -O2 -Werror
 
 common opts-lib
   ghc-options:
-    -Wall -Wcompat -Wredundant-constraints -Wincomplete-uni-patterns
+    -Wall -Wcompat -Wno-redundant-constraints -Wincomplete-uni-patterns
     -Wincomplete-record-updates -Wunused-packages
 
   if flag(release)
@@ -70,11 +70,14 @@ library
     Data.Bag
     Data.Monoid.Extra
     Data.Monoid.Refinement
+    Data.Table
   other-modules:
     Data.Bag.Def
     Data.Bag.Quotient
     Data.Bag.Raw
+    Data.Table.Def
   autogen-modules:
     Data.Bag.Def
     Data.Bag.Raw
     Data.Monoid.Refinement
+    Data.Table.Def

--- a/lib/bags/haskell/Data/Table.hs
+++ b/lib/bags/haskell/Data/Table.hs
@@ -1,0 +1,5 @@
+module Data.Table
+    ( module Data.Table.Def
+    ) where
+
+import Data.Table.Def

--- a/lib/bags/haskell/Data/Table/Def.hs
+++ b/lib/bags/haskell/Data/Table/Def.hs
@@ -1,0 +1,48 @@
+module Data.Table.Def where
+
+import Prelude hiding (null, filter, map, concatMap)
+import qualified Data.Bag.Def as Bag (cartesianProduct)
+import Data.Bag.Quotient (Bag, foldBag)
+import qualified Data.Bag.Quotient as Bag (singleton)
+import Data.Map (Map)
+import qualified Data.Map as Map (empty, intersectionWith, lookup, singleton, unionWith)
+import qualified Data.Monoid.Refinement (Commutative)
+
+isJust :: Maybe a -> Bool
+isJust Nothing = False
+isJust (Just _) = True
+
+mergeRaw ::
+           Ord k => Map k (Bag a) -> Map k (Bag b) -> Map k (Bag (a, b))
+mergeRaw = Map.intersectionWith Bag.cartesianProduct
+
+newtype Table k a = MkTable{getTable :: Map k (Bag a)}
+
+toBag :: Maybe (Bag a) -> Bag a
+toBag Nothing = mempty
+toBag (Just x) = x
+
+lookup :: Ord k => k -> Table k a -> Bag a
+lookup = \ key -> toBag . Map.lookup key . \ r -> getTable r
+
+singleton :: Ord k => k -> a -> Table k a
+singleton key x = MkTable (Map.singleton key (Bag.singleton x))
+
+instance (Ord k) => Semigroup (Table k a) where
+    MkTable xs <> MkTable ys = MkTable (Map.unionWith (<>) xs ys)
+
+instance (Ord k) => Monoid (Table k a) where
+    mempty = MkTable Map.empty
+
+instance (Ord k) => Data.Monoid.Refinement.Commutative (Table k a)
+         where
+
+indexBy :: Ord k => Bag a -> (a -> k) -> Table k a
+indexBy xs f = foldBag (\ x -> singleton (f x) x) xs
+
+elements :: Ord k => Table k a -> Bag a
+elements = foldMap id . \ r -> getTable r
+
+merge :: Ord k => Table k a -> Table k b -> Table k (a, b)
+merge xs ys = MkTable (mergeRaw (getTable xs) (getTable ys))
+


### PR DESCRIPTION
This pull request exports the type `Table k a` in a module `Data.Table` to Haskell, including operations `indexBy` and `merge`.

This code has been proven (up to postulates on `Data.Map`) to yield an efficient implementation of `equijoin` on `Bag`:

```agda
@0 prop-equijoin-indexBy
  : ∀ {k} ⦃ _ : Ord k ⦄ ⦃ _ : IsLawfulEq k ⦄
      (f : a → k) (g : b → k) (xs : Bag a) (ys : Bag b)
  → Bag.equijoin f g xs ys
    ≡ elements (merge (indexBy xs f) (indexBy ys g))
```