### PR TITLE
Prove `IsCommutativeMonad Bag`

### DIFF
--- a/lib/bags/agda/Data/Bag/Prop.agda
+++ b/lib/bags/agda/Data/Bag/Prop.agda
@@ -31,7 +31,7 @@ open import Control.Monad.Prop as Monad
 record IsCommutativeMonad (m : Type → Type) ⦃ _ : Monad m ⦄ : Type₁ where
   field
     -- Different monadic actions commute
-    prop-monad-sym : ∀ {a b : Type} (mx : m a) (my : m b) (mz : a → b → m c)
+    prop-monad-sym : ∀ {a b} (mx : m a) (my : m b) (mz : a → b → m c)
       → mx >>= (λ x → my >>= (λ y → mz x y))
         ≡ my >>= (λ y → mx >>= (λ x → mz x y))
 
@@ -127,8 +127,18 @@ instance
   iDistributiveMonadPlusBag : IsDistributiveMonadPlus Bag
   iDistributiveMonadPlusBag .mplus-bind x y k = prop-foldBag-<> k x y
 
-postulate instance
-  iCommutativeMonadBag      : IsCommutativeMonad Bag
+  iCommutativeMonadBag : IsCommutativeMonad Bag
+  iCommutativeMonadBag .IsCommutativeMonad.prop-monad-sym mx my mz =
+      prop-Bag-equality-2 lhs rhs
+        (λ xs → Monoid.prop-morphism-∘ _ _ (Monoid.prop-morphism-curry _ (λ x → prop-morphism-foldBag _)) (prop-morphism-foldBag-fun xs))
+        (λ xs → prop-morphism-foldBag _)
+        (λ ys → prop-morphism-foldBag _)
+        (λ ys → Monoid.prop-morphism-∘ _ _ (Monoid.prop-morphism-curry _ (λ y → prop-morphism-foldBag _)) (prop-morphism-foldBag-fun ys))
+        (λ x y → refl)
+        mx my
+    where
+      lhs = λ xs ys → xs >>= (λ x → ys >>= (λ y → mz x y))
+      rhs = λ xs ys → ys >>= (λ y → xs >>= (λ x → mz x y))
 
 {-----------------------------------------------------------------------------
     Properties

--- a/lib/bags/agda/Data/Bag/Quotient/Prop.agda
+++ b/lib/bags/agda/Data/Bag/Quotient/Prop.agda
@@ -137,6 +137,16 @@ prop-foldBag-function-<> {a} f g =
         rhs xs <> rhs ys
       ∎
 
+-- | 'foldBag' is a homomorphism in the function argument as well.
+prop-morphism-foldBag-fun
+  : ∀ {a b} ⦃ _ : Monoid.Commutative b ⦄ ⦃ _ : IsLawfulMonoid b ⦄ (xs : Bag a)
+  → Monoid.IsHomomorphism (λ (f : a → b) → foldBag f xs)
+--
+prop-morphism-foldBag-fun xs =
+  Monoid.MkIsHomomorphism
+    (prop-foldBag-function-mempty xs)
+    (λ f g → prop-foldBag-function-<> f g xs)
+
 -- | 'foldBag' that maps to 'singleton' is the identity.
 prop-foldBag-function-singleton
   : ∀ (xs : Bag b)

--- a/lib/bags/agda/Data/Monoid/Morphism.agda
+++ b/lib/bags/agda/Data/Monoid/Morphism.agda
@@ -5,6 +5,7 @@ open import Haskell.Prim
 open import Haskell.Prim.Monoid
 
 open import Haskell.Law
+open import Haskell.Law.Extensionality
 
 -------------------------------------------------------------------------------
 -- Monoid Homomorphisms
@@ -38,3 +39,15 @@ prop-morphism-∘ f g prop-f prop-g = record
   ; homo-<> = λ x y →
     trans (cong g (homo-<> prop-f x y)) (homo-<> prop-g (f x) (f y))
   }
+
+-- | Parametrizations of homomorphisms are homomorphisms.
+--
+-- @f@ can be viewed as a function
+-- from the @Monoid a@ to the @Monoid (b → c)@.
+prop-morphism-curry
+  : ∀ ⦃ _ : Monoid a ⦄ ⦃ _ : Monoid c ⦄ (f : a → b → c)
+  → (∀ y → IsHomomorphism (λ x → f x y))
+  → IsHomomorphism f
+--
+prop-morphism-curry f eq .homo-mempty = ext (λ y → eq y .homo-mempty)
+prop-morphism-curry f eq .homo-<> x1 x2 = ext (λ y → eq y .homo-<> x1 x2)


### PR DESCRIPTION
This pull request adds the proof that `Bag` is a commutative `Monad`, i.e. the order in which monadic operations are performed does not matter.

The proof relies on the observation that `foldBag f xs` is a monoid homomorphism in the function argument `f` as well. We use function extensionality.