### PR TITLE
Add `IsLawfulMonoid` constraints

### DIFF
--- a/lib/bags/agda/Data/Bag/Prop.agda
+++ b/lib/bags/agda/Data/Bag/Prop.agda
@@ -66,7 +66,8 @@ prop-size-<> xs ys = refl
 ------------------------------------------------------------------------------}
 --
 prop-foldBag-associative
-  : ∀ ⦃ _ : Monoid.Commutative c ⦄ (g : b → c) (f : a → Bag b) (xs : Bag a)
+  : ∀ ⦃ _ : Monoid.Commutative c ⦄ ⦃ _ : IsLawfulMonoid c ⦄
+    (g : b → c) (f : a → Bag b) (xs : Bag a)
   → foldBag (foldBag g ∘ f) xs ≡ foldBag g (foldBag f xs)
 --
 prop-foldBag-associative g f =

--- a/lib/bags/agda/Data/Bag/Quotient/Prop.agda
+++ b/lib/bags/agda/Data/Bag/Quotient/Prop.agda
@@ -32,7 +32,7 @@ prop-morphism-foldBag f = Monoid.MkIsHomomorphism refl (λ x y → refl)
 -- * And they are equal on 'singleton'.
 --   With the rewrite rules, this property can be computed.
 prop-Bag-equality
-  : ∀ ⦃ _ : Monoid.Commutative b ⦄ (f g : Bag a → b)
+  : ∀ ⦃ _ : Monoid.Commutative b ⦄ ⦃ _ : IsLawfulMonoid b ⦄ (f g : Bag a → b)
   → @0 Monoid.IsHomomorphism f → @0 Monoid.IsHomomorphism g
   → (∀ x → f (singleton x) ≡ g (singleton x))
   → ∀ xs → f xs ≡ g xs
@@ -50,7 +50,7 @@ prop-Bag-equality f g hom-f hom-g eq-singleton xs =
 
 -- | Proof principle for functions with two 'Bag' arguments.
 prop-Bag-equality-2
-  : ∀ ⦃ _ : Monoid.Commutative c ⦄ (f g : Bag a → Bag b → c)
+  : ∀ ⦃ _ : Monoid.Commutative c ⦄ ⦃ _ : IsLawfulMonoid c ⦄ (f g : Bag a → Bag b → c)
   → @0 (∀ xs → Monoid.IsHomomorphism (λ ys → f xs ys))
   → @0 (∀ xs → Monoid.IsHomomorphism (λ ys → g xs ys))
   → @0 (∀ ys → Monoid.IsHomomorphism (λ xs → f xs ys))

--- a/lib/bags/agda/Data/Map/Prop/Extra.agda
+++ b/lib/bags/agda/Data/Map/Prop/Extra.agda
@@ -79,6 +79,73 @@ module _ {k : Type} ⦃ _ : Ord k ⦄ where
 
 {-----------------------------------------------------------------------------
     Proofs
+    unionWith
+------------------------------------------------------------------------------}
+module _ {k : Type} ⦃ _ : Ord k ⦄ where
+
+  --
+  prop-unionWith-empty-x
+    : ∀ {f : a → a → a} {ma : Map k a}
+    → unionWith f empty ma ≡ ma
+  --
+  prop-unionWith-empty-x {a} {f} {ma} = prop-equality eq-key
+    where
+      eq-key
+        : ∀ (key : k)
+        → lookup key (unionWith f empty ma)
+          ≡ lookup key ma
+      eq-key key
+        rewrite prop-lookup-unionWith key f empty ma
+        rewrite prop-lookup-empty {k} {a} key
+        = refl
+
+  --
+  prop-unionWith-x-empty
+    : ∀ {f : a → a → a} {ma : Map k a}
+    → unionWith f ma empty ≡ ma
+  --
+  prop-unionWith-x-empty {a} {f} {ma} = prop-equality eq-key
+    where
+      eq-key
+        : ∀ (key : k)
+        → lookup key (unionWith f ma empty)
+          ≡ lookup key ma
+      eq-key key
+        rewrite prop-lookup-unionWith key f ma empty
+        rewrite prop-lookup-empty {k} {a} key
+        with lookup key ma
+      ... | Nothing = refl
+      ... | Just x  = refl
+
+  --
+  prop-unionWith-assoc
+    : ∀ {f : a → a → a} {ma mb mc : Map k a}
+    → (∀ x y z → f (f x y) z ≡ f x (f y z))
+    → unionWith f (unionWith f ma mb) mc
+      ≡ unionWith f ma (unionWith f mb mc)
+  --
+  prop-unionWith-assoc {a} {f} {ma} {mb} {mc} f-assoc = prop-equality eq-key
+    where
+      eq-key
+        : ∀ (key : k)
+        → lookup key (unionWith f (unionWith f ma mb) mc)
+          ≡ lookup key (unionWith f ma (unionWith f mb mc))
+      eq-key key
+        rewrite prop-lookup-unionWith key f (unionWith f ma mb) mc
+        rewrite prop-lookup-unionWith key f ma (unionWith f mb mc)
+        rewrite prop-lookup-unionWith key f ma mb
+        rewrite prop-lookup-unionWith key f mb mc
+        with lookup key ma | lookup key mb
+      ... | Nothing | Nothing = refl
+      ... | Nothing | Just y  = refl
+      ... | Just x  | Nothing = refl
+      ... | Just x  | Just y
+          with lookup key mc
+      ...   | Nothing = refl
+      ...   | Just z  = cong Just (f-assoc x y z)
+
+{-----------------------------------------------------------------------------
+    Proofs
     intersectionWith
 ------------------------------------------------------------------------------}
 module _ {k : Type} ⦃ _ : Ord k ⦄ where

--- a/lib/bags/agda/Data/Table/Def.agda
+++ b/lib/bags/agda/Data/Table/Def.agda
@@ -134,7 +134,7 @@ open Table public
 {-# COMPILE AGDA2HS Table newtype #-}
 
 -- | Two Tables are equal if they contain the same 'Map'.
-@0 prop-Table-equality
+prop-Table-equality
   : ∀ {k} ⦃ _ : Ord k ⦄ {xs ys : Table k a}
   → getTable xs ≡ getTable ys
   → xs ≡ ys
@@ -179,7 +179,7 @@ instance
 {-# COMPILE AGDA2HS iMonoidTable #-}
 
 -- | Union with the empty 'Table' on the left is empty.
-@0 prop-Table-<>-mempty-x
+prop-Table-<>-mempty-x
   : ∀ {k} ⦃ _ : Ord k ⦄ (xs : Table k a)
   → mempty <> xs ≡ xs
 --
@@ -187,7 +187,7 @@ prop-Table-<>-mempty-x {a} (MkTable xs inv-x) =
   prop-Table-equality Map.prop-unionWith-empty-x
 
 -- | Union with the empty 'Table' on the right is empty.
-@0 prop-Table-<>-x-mempty
+prop-Table-<>-x-mempty
   : ∀ {k} ⦃ _ : Ord k ⦄ (xs : Table k a)
   → xs <> mempty ≡ xs
 --
@@ -195,7 +195,7 @@ prop-Table-<>-x-mempty {a} (MkTable xs inv-x) =
   prop-Table-equality Map.prop-unionWith-x-empty
 
 -- | Union of 'Table' is associative
-@0 prop-Table-<>-assoc
+prop-Table-<>-assoc
   : ∀ {k} ⦃ _ : Ord k ⦄ (xs ys zs : Table k a)
   → (xs <> ys) <> zs ≡ xs <> (ys <> zs)
 --
@@ -205,11 +205,11 @@ prop-Table-<>-assoc {a} (MkTable xs inv-x) (MkTable ys inv-y) (MkTable zs inv-z)
     prop-f-assoc = λ x y z → sym (Monoid.associativity x y z)
 
 instance
-  @0 isLawfulSemigroupTable : ∀ {k} ⦃ _ : Ord k ⦄ → Monoid.IsLawfulSemigroup (Table k a)
+  isLawfulSemigroupTable : ∀ {k} ⦃ _ : Ord k ⦄ → Monoid.IsLawfulSemigroup (Table k a)
   isLawfulSemigroupTable .Monoid.associativity =
     λ x y z → sym (prop-Table-<>-assoc x y z)
 
-  @0 isLawfulMonoidTable : ∀ {k} ⦃ _ : Ord k ⦄ → Monoid.IsLawfulMonoid (Table k a)
+  isLawfulMonoidTable : ∀ {k} ⦃ _ : Ord k ⦄ → Monoid.IsLawfulMonoid (Table k a)
   isLawfulMonoidTable .Monoid.leftIdentity = prop-Table-<>-mempty-x
   isLawfulMonoidTable .Monoid.rightIdentity = prop-Table-<>-x-mempty
   isLawfulMonoidTable .Monoid.concatenation [] = refl

--- a/lib/bags/agda/Haskell/Data/Bag/Quotient.agda
+++ b/lib/bags/agda/Haskell/Data/Bag/Quotient.agda
@@ -67,7 +67,7 @@ postulate
 
   -- Universal property, uniqueness
   prop-foldBag-unique
-    : ∀ ⦃ _ : Monoid.Commutative b ⦄ (g : Bag a → b)
+    : ∀ ⦃ _ : Monoid.Commutative b ⦄ ⦃ _ : IsLawfulMonoid b ⦄ (g : Bag a → b)
     → @0 Monoid.IsHomomorphism g
     → ∀ (xs : Bag a) → foldBag (g ∘ singleton) xs ≡ g xs
 


### PR DESCRIPTION
This pull request adds the `IsLawfulMonoid` constraint to `prop-foldBag-unique`. Strictly speaking, the property would be wrong without it.

Ideally, we would make `IsLawfulMonoid` a consequence of `Commutative`, but this would require more erasure annotations than I'm willing to introduce right now.