### PR TITLE
Implement `deleteOne` using a monoid `Found`

### DIFF
--- a/lib/bags/agda/Data/Bag.agda
+++ b/lib/bags/agda/Data/Bag.agda
@@ -3,3 +3,4 @@ module Data.Bag where
 open import Haskell.Data.Bag        public
 open import Data.Bag.Quotient.Prop  public
 open import Data.Bag.Prop           public
+open import Data.Bag.Found          public using (deleteOne)

--- a/lib/bags/agda/Data/Bag/Def.agda
+++ b/lib/bags/agda/Data/Bag/Def.agda
@@ -160,9 +160,16 @@ count x = size ∘ filter (x ==_)
 
 {-# COMPILE AGDA2HS count #-}
 
--- | Check whether an item is contained in the 'Bag' at least once.
+-- | Test whether an item is contained in the 'Bag' at least once,
+-- 'Monoid' version.
+mmember : ⦃ Eq a ⦄ → a → Bag a → Disj
+mmember x = foldBag (λ y → if x == y then MkDisj True else mempty)
+
+{-# COMPILE AGDA2HS mmember #-}
+
+-- | Test whether an item is contained in the 'Bag' at least once.
 member : ⦃ Eq a ⦄ → a → Bag a → Bool
-member x ys = 0 < count x ys
+member x = getDisj ∘ mmember x
 
 {-# COMPILE AGDA2HS member #-}
 

--- a/lib/bags/agda/Data/Bag/Prop.agda
+++ b/lib/bags/agda/Data/Bag/Prop.agda
@@ -214,6 +214,13 @@ prop-morphism-mnull
 --
 prop-morphism-mnull = prop-morphism-foldBag _
 
+-- | 'member' is a monoid homomorphism.
+prop-morphism-mmember
+  : ∀ ⦃ _ : Eq a ⦄ (x : a)
+  → Monoid.IsHomomorphism ⦃ iMonoidBag {a} ⦄ (mmember x)
+--
+prop-morphism-mmember _ = prop-morphism-foldBag _
+
 -- | 'cartesianProduct' is a monoid homomorphism in its first argument.
 prop-morphism-cartesianProduct-1
   : ∀ (ys : Bag b)

--- a/lib/bags/agda/Data/Monoid/Extra.agda
+++ b/lib/bags/agda/Data/Monoid/Extra.agda
@@ -6,6 +6,7 @@ open import Haskell.Law.Equality
 open import Haskell.Law.Monoid
 open import Haskell.Law.Num
 
+-------------------------------------------------------------------------------
 -- Boolean monoid under conjunction '(&&)'.
 record Conj : Type where
   constructor MkConj
@@ -43,6 +44,45 @@ instance
 {-# COMPILE AGDA2HS iSemigroupConj #-}
 {-# COMPILE AGDA2HS iMonoidConj #-}
 
+-------------------------------------------------------------------------------
+-- Boolean monoid under disjunction '(||)'.
+record Disj : Type where
+  constructor MkDisj
+  field
+    getDisj : Bool
+
+open Disj public
+
+{-# COMPILE AGDA2HS Disj newtype #-}
+
+instance
+  iSemigroupDisj : Semigroup Disj
+  iSemigroupDisj ._<>_ (MkDisj x) (MkDisj y) = MkDisj (x || y)
+
+  iDefaultMonoidDisj : DefaultMonoid Disj
+  iDefaultMonoidDisj .DefaultMonoid.mempty = record{getDisj = False}
+
+  iMonoidDisj : Monoid Disj
+  iMonoidDisj = record{DefaultMonoid iDefaultMonoidDisj}
+
+  isLawfulSemigroupDisj : IsLawfulSemigroup Disj
+  isLawfulSemigroupDisj .associativity (MkDisj False) y z = refl
+  isLawfulSemigroupDisj .associativity (MkDisj True) y z = refl
+
+  isLawfulMonoidDisj : IsLawfulMonoid Disj
+  isLawfulMonoidDisj .rightIdentity (MkDisj False) = refl
+  isLawfulMonoidDisj .rightIdentity (MkDisj True) = refl
+  isLawfulMonoidDisj .leftIdentity (MkDisj False) = refl
+  isLawfulMonoidDisj .leftIdentity (MkDisj True) = refl
+  isLawfulMonoidDisj .concatenation [] = refl
+  isLawfulMonoidDisj .concatenation (x ∷ xs)
+    rewrite (concatenation {{_}} {{isLawfulMonoidDisj}} xs)
+    = refl
+
+{-# COMPILE AGDA2HS iSemigroupDisj #-}
+{-# COMPILE AGDA2HS iMonoidDisj #-}
+
+-------------------------------------------------------------------------------
 -- Monoid under addition.
 record Sum' a : Type where
   constructor MkSum

--- a/lib/bags/agda/Data/Monoid/Refinement.agda
+++ b/lib/bags/agda/Data/Monoid/Refinement.agda
@@ -62,6 +62,11 @@ instance
   iCommutativeConj .commutative record{getConj = x} record{getConj = y}
     = cong (λ o → record{getConj = o}) (prop-&&-sym x y)
 
+  iCommutativeDisj : Commutative Disj
+  iCommutativeDisj .monoid = iMonoidDisj
+  iCommutativeDisj .commutative record{getDisj = x} record{getDisj = y}
+    = cong (λ o → record{getDisj = o}) (prop-||-sym x y)
+
   iCommutativeSum' : ⦃ _ : Num a ⦄ → @0 ⦃ IsLawfulNum a ⦄ → Commutative (Sum' a)
   iCommutativeSum' .monoid = iMonoidSum'
   iCommutativeSum' .commutative record{getSum' = x} record{getSum' = y}
@@ -71,6 +76,7 @@ instance
 {-# COMPILE AGDA2HS iCommutativeTuple₂ #-}
 {-# COMPILE AGDA2HS iCommutativeTuple₃ #-}
 {-# COMPILE AGDA2HS iCommutativeConj #-}
+{-# COMPILE AGDA2HS iCommutativeDisj #-}
 {-# COMPILE AGDA2HS iCommutativeSum' #-}
 
 {- *-comm is not part of IsLawfulNum yet?!

--- a/lib/bags/agda/Data/Table/Def.agda
+++ b/lib/bags/agda/Data/Table/Def.agda
@@ -21,9 +21,9 @@ import Data.Monoid.Refinement as Monoid
 
 ------------------------------------------------------------------------------
 -- Move out: Elimination of irrelevant ⊥
-
-⊥-elim-irr : ∀ {ℓ} {Whatever : Type ℓ} → .⊥ → Whatever
-⊥-elim-irr ()
+private
+  ⊥-elim-irr : ∀ {ℓ} {Whatever : Type ℓ} → .⊥ → Whatever
+  ⊥-elim-irr ()
 
 ------------------------------------------------------------------------------
 -- Move out: Helper function on "Data.Maybe"

--- a/lib/bags/agda/bags.agda
+++ b/lib/bags/agda/bags.agda
@@ -16,4 +16,6 @@ import Data.Bag.Raw
 
 import Data.Table
 
+import Data.Bag.Found
+
 import Data.BagOld -- to be absorbed

--- a/lib/bags/bags.cabal
+++ b/lib/bags/bags.cabal
@@ -68,12 +68,12 @@ library
 
   exposed-modules:
     Data.Bag
-    Data.Bag.Found
     Data.Monoid.Extra
     Data.Monoid.Refinement
     Data.Table
   other-modules:
     Data.Bag.Def
+    Data.Bag.Found
     Data.Bag.Quotient
     Data.Bag.Raw
     Data.Table.Def

--- a/lib/bags/bags.cabal
+++ b/lib/bags/bags.cabal
@@ -68,6 +68,7 @@ library
 
   exposed-modules:
     Data.Bag
+    Data.Bag.Found
     Data.Monoid.Extra
     Data.Monoid.Refinement
     Data.Table

--- a/lib/bags/haskell/Data/Bag.hs
+++ b/lib/bags/haskell/Data/Bag.hs
@@ -3,7 +3,9 @@ module Data.Bag
       module Data.Bag.Quotient
     -- * Operations
     , module Data.Bag.Def
+    , deleteOne
     ) where
 
 import Data.Bag.Def
 import Data.Bag.Quotient
+import Data.Bag.Found

--- a/lib/bags/haskell/Data/Bag/Def.hs
+++ b/lib/bags/haskell/Data/Bag/Def.hs
@@ -4,7 +4,7 @@ module Data.Bag.Def where
 
 import Prelude hiding (null, filter, map, concatMap)
 import Data.Bag.Quotient (Bag, foldBag, singleton)
-import Data.Monoid.Extra (Conj(MkConj, getConj), Sum'(MkSum, getSum'))
+import Data.Monoid.Extra (Conj(MkConj, getConj), Disj(MkDisj, getDisj), Sum'(MkSum, getSum'))
 import Data.Monoid.Refinement ()
 
 
@@ -68,8 +68,11 @@ filter p xs
 count :: Eq a => a -> Bag a -> Int
 count x = size . filter (x ==)
 
+mmember :: Eq a => a -> Bag a -> Disj
+mmember x = foldBag (\ y -> if x == y then MkDisj True else mempty)
+
 member :: Eq a => a -> Bag a -> Bool
-member x ys = 0 < count x ys
+member x = (\ r -> getDisj r) . mmember x
 
 cartesianProduct :: Bag a -> Bag b -> Bag (a, b)
 cartesianProduct xs ys

--- a/lib/bags/haskell/Data/Bag/Found.hs
+++ b/lib/bags/haskell/Data/Bag/Found.hs
@@ -24,3 +24,16 @@ instance Semigroup (Found a) where
 instance Monoid (Found a) where
     mempty = emptyFound
 
+here :: a -> Found a
+here x = MkFound (Just x) mempty
+
+elsewhere :: a -> Found a
+elsewhere y = MkFound Nothing (singleton y)
+
+putBack :: Found a -> Bag a
+putBack (MkFound Nothing xs) = xs
+putBack (MkFound (Just x) xs) = singleton x <> xs
+
+findOne :: Eq a => a -> a -> Found a
+findOne x y = if x == y then here y else elsewhere y
+

--- a/lib/bags/haskell/Data/Bag/Found.hs
+++ b/lib/bags/haskell/Data/Bag/Found.hs
@@ -1,7 +1,8 @@
 module Data.Bag.Found where
 
 import Prelude hiding (null, filter, map, concatMap)
-import Data.Bag.Quotient (Bag, singleton)
+import Data.Bag.Quotient (Bag, foldBag, singleton)
+import qualified Data.Monoid.Refinement (Commutative)
 
 data Found a = MkFound{found :: Maybe a, rest :: Bag a}
 
@@ -34,6 +35,12 @@ putBack :: Found a -> Bag a
 putBack (MkFound Nothing xs) = xs
 putBack (MkFound (Just x) xs) = singleton x <> xs
 
+instance (Eq a) => Data.Monoid.Refinement.Commutative (Found a)
+         where
+
 findOne :: Eq a => a -> a -> Found a
 findOne x y = if x == y then here y else elsewhere y
+
+deleteOne :: Eq a => a -> Bag a -> Bag a
+deleteOne x = (\ r -> rest r) . foldBag (findOne x)
 

--- a/lib/bags/haskell/Data/Bag/Found.hs
+++ b/lib/bags/haskell/Data/Bag/Found.hs
@@ -1,0 +1,26 @@
+module Data.Bag.Found where
+
+import Prelude hiding (null, filter, map, concatMap)
+import Data.Bag.Quotient (Bag, singleton)
+
+data Found a = MkFound{found :: Maybe a, rest :: Bag a}
+
+emptyFound :: Found a
+emptyFound = MkFound Nothing mempty
+
+unionFound :: Found a -> Found a -> Found a
+unionFound (MkFound Nothing r1) (MkFound Nothing r2)
+  = MkFound Nothing (r1 <> r2)
+unionFound (MkFound Nothing r1) (MkFound (Just y2) r2)
+  = MkFound (Just y2) (r1 <> r2)
+unionFound (MkFound (Just y1) r1) (MkFound Nothing r2)
+  = MkFound (Just y1) (r1 <> r2)
+unionFound (MkFound (Just y1) r1) (MkFound (Just y2) r2)
+  = MkFound (Just y1) (r1 <> singleton y2 <> r2)
+
+instance Semigroup (Found a) where
+    (<>) = unionFound
+
+instance Monoid (Found a) where
+    mempty = emptyFound
+

--- a/lib/bags/haskell/Data/Monoid/Extra.hs
+++ b/lib/bags/haskell/Data/Monoid/Extra.hs
@@ -10,6 +10,14 @@ instance Semigroup Conj where
 instance Monoid Conj where
     mempty = MkConj True
 
+newtype Disj = MkDisj{getDisj :: Bool}
+
+instance Semigroup Disj where
+    MkDisj x <> MkDisj y = MkDisj (x || y)
+
+instance Monoid Disj where
+    mempty = MkDisj False
+
 newtype Sum' a = MkSum{getSum' :: a}
 
 instance (Num a) => Semigroup (Sum' a) where

--- a/lib/bags/haskell/Data/Monoid/Refinement.hs
+++ b/lib/bags/haskell/Data/Monoid/Refinement.hs
@@ -1,7 +1,7 @@
 module Data.Monoid.Refinement where
 
 import Prelude hiding (null, filter, map, concatMap)
-import Data.Monoid.Extra (Conj, Sum')
+import Data.Monoid.Extra (Conj, Disj, Sum')
 
 class Monoid a => Commutative a where
 
@@ -15,6 +15,8 @@ instance (Commutative a, Commutative b, Commutative c) =>
          where
 
 instance Commutative Conj where
+
+instance Commutative Disj where
 
 instance (Num a) => Commutative (Sum' a) where
 


### PR DESCRIPTION
This pull request implements the function `deleteOne` which deletes a single item from a `Bag`. In the event that the `Bag` contains multiple copies of this item, only a single copy is removed.

The implementation of `deleteOne` in terms of `foldBag` is somewhat tricky, as `deleteOne` by itself is not a monoid homomorphism. However, `deleteOne` can be implemented by first mapping to an appropriate monoid — which we call `Found` — and then projecting to a component. This monoid `Found` stores both the item if found, and a `Bag` where this item has been deleted. The tricky part is to prove that this monoid is commutative — we need to keep track of the item in the type.

The function `deleteOne` is characterized by the two properties

```agda
prop-deleteOne-member-True
  : ∀ ⦃ _ : Eq a ⦄ ⦃ _ : IsLawfulEq a ⦄ (x : a) (xs : Bag a)
  → member x xs ≡ True
  → xs ≡ singleton x <> deleteOne x xs

prop-deleteOne-member-False
  : ∀ ⦃ _ : Eq a ⦄ ⦃ _ : IsLawfulEq a ⦄ (x : a) (xs : Bag a)
  → member x xs ≡ False
  → xs ≡ deleteOne x xs
```

Again, since `deleteOne` is not a monoid homomorphism, the proof of these properties has to go through the `Found` monoid again. In addition, we express `member` in terms of a monoid in order to apply the uniqueness of `foldBag`.