### PR TITLE
Add proofs about `Data.Bag.Counts`

### DIFF
--- a/lib/bags/agda/Data/Bag/Counts.agda
+++ b/lib/bags/agda/Data/Bag/Counts.agda
@@ -102,6 +102,8 @@ replicatePositiveNat : PositiveNat → a → Bag a
 replicatePositiveNat n x =
   mconcat $ replicateNat (natFromPositiveNat n) (Bag.singleton x)
 
+{-# COMPILE AGDA2HS replicatePositiveNat #-}
+
 --
 prop-replicatePositiveNat-<>
   : ∀ (m n : PositiveNat) (x : a)
@@ -229,14 +231,14 @@ instance
     Operations
     Bag
 ------------------------------------------------------------------------------}
-toCounts' : ∀ ⦃ _ : Ord a ⦄ → Bag a → Counts a
-toCounts' = foldBag (λ x → singleton x)
+mtoCounts : ∀ ⦃ _ : Ord a ⦄ → Bag a → Counts a
+mtoCounts = foldBag (λ x → singleton x)
 
-{-# COMPILE AGDA2HS toCounts' #-}
+{-# COMPILE AGDA2HS mtoCounts #-}
 
 -- | Convert a 'Bag' to a mapping from items to their number of occurrences.
 toCounts : ⦃ Ord a ⦄ → Bag a → Map.Map a Nat
-toCounts = fmap natFromPositiveNat ∘ getCounts ∘ toCounts'
+toCounts = fmap natFromPositiveNat ∘ getCounts ∘ mtoCounts
 
 {-# COMPILE AGDA2HS toCounts #-}
 
@@ -251,6 +253,8 @@ fromCounts = foldMap id ∘ Map.mapWithKey (flip replicateBag)
 
 {-# COMPILE AGDA2HS fromCounts #-}
 
-fromCounts' : ⦃ _ : Ord a ⦄ → Counts a → Bag a
-fromCounts' =
+mfromCounts : ⦃ _ : Ord a ⦄ → Counts a → Bag a
+mfromCounts =
   foldMap id ∘ Map.mapWithKey (flip replicatePositiveNat) ∘ getCounts
+
+{-# COMPILE AGDA2HS mfromCounts #-}

--- a/lib/bags/agda/Data/Bag/Counts.agda
+++ b/lib/bags/agda/Data/Bag/Counts.agda
@@ -105,6 +105,14 @@ replicatePositiveNat n x =
 {-# COMPILE AGDA2HS replicatePositiveNat #-}
 
 --
+prop-replicatePositiveNat-one
+  : ∀ (x : a) → replicatePositiveNat one x ≡ Bag.singleton x
+--
+prop-replicatePositiveNat-one x
+  rewrite Monoid.concatenation (Bag.singleton x ∷ [])
+  = Monoid.rightIdentity _
+
+--
 prop-replicatePositiveNat-<>
   : ∀ (m n : PositiveNat) (x : a)
   → replicatePositiveNat (m <> n) x

--- a/lib/bags/agda/Data/Bag/Prop/Conversion.agda
+++ b/lib/bags/agda/Data/Bag/Prop/Conversion.agda
@@ -1,0 +1,112 @@
+module Data.Bag.Prop.Conversion
+  {-|
+  -- * Conversion
+  ; prop-morphism-mtoCounts
+  ; prop-morphism-mfromCounts
+  ; prop-mfromCounts-mtoCounts
+  -} where
+
+open import Haskell.Data.Bag.Quotient as Bag
+open import Data.Bag.Def
+open import Data.Bag.Counts
+open import Data.Bag.Prop.Core
+
+open import Haskell.Prelude
+open import Haskell.Law.Eq
+open import Haskell.Law.Equality
+
+import      Data.Map as Map
+open import Data.Map using (Map)
+import      Data.Map.Prop.Extra as Map
+import      Data.Monoid.Refinement as Monoid
+import      Data.Monoid.Morphism as Monoid
+
+{-# FOREIGN AGDA2HS
+{-# OPTIONS_GHC -Wno-unused-top-binds #-}
+#-}
+dummyPropConversion : ⊤
+dummyPropConversion = tt
+{-# COMPILE AGDA2HS dummyPropConversion #-}
+
+{-----------------------------------------------------------------------------
+    Properties
+    maps of Bags
+------------------------------------------------------------------------------}
+-- | @'foldMap' 'id'@ on an empty 'Map' gives the empty 'Bag'.
+prop-Bag-fold-mempty
+  : ∀ {k} ⦃ _ : Ord k ⦄
+  → foldMap id (Map.empty {k}) ≡ mempty {Bag a}
+--
+prop-Bag-fold-mempty {a} {k = k}
+  rewrite Map.prop-toAscList-empty {k = k} {a = Bag a}
+  = refl
+
+-- | @'foldMap' 'id'@ commutes with 'Bag'.
+prop-Bag-fold-<>
+  : ∀ {k} ⦃ _ : Ord k ⦄ (xs ys : Map k (Bag a))
+  → foldMap id (Map.unionWith (_<>_) xs ys)
+    ≡ foldMap id xs <> foldMap id ys
+--
+prop-Bag-fold-<> xs ys = Map.prop-fold-unionWith xs ys
+
+{-----------------------------------------------------------------------------
+    Properties
+    Counts
+------------------------------------------------------------------------------}
+-- | 'Data.Bag.Counts.mtoCounts' is a monoid homomorphism.
+prop-morphism-mtoCounts
+  : ⦃ _ : Ord a ⦄ → Monoid.IsHomomorphism (mtoCounts {a})
+--
+prop-morphism-mtoCounts = prop-morphism-foldBag _
+
+-- | 'Data.Bag.Counts.mfromCounts' is a monoid homomorphism.
+prop-morphism-mfromCounts
+  : ⦃ _ : Ord a ⦄ → Monoid.IsHomomorphism (mfromCounts {a})
+--
+prop-morphism-mfromCounts {a} .Monoid.homo-mempty =
+  begin
+    (foldMap id $ Map.mapWithKey (flip replicatePositiveNat) $ getCounts mempty)
+  ≡⟨ cong (foldMap id) (Map.prop-mapWithKey-empty _) ⟩
+    foldMap id (Map.empty {a})
+  ≡⟨ prop-Bag-fold-mempty ⟩
+    mempty
+  ∎
+prop-morphism-mfromCounts .Monoid.homo-<> xs ys =
+  begin
+    (foldMap id $ Map.mapWithKey (flip replicatePositiveNat) $ getCounts (xs <> ys))
+  ≡⟨ cong (foldMap id) (Map.prop-mapWithKey-unionWith _ _ _ _ _ λ key x y → prop-replicatePositiveNat-<> x y key) ⟩
+    (foldMap id $ Map.unionWith (_<>_)
+      (Map.mapWithKey (flip replicatePositiveNat) (getCounts xs))
+      (Map.mapWithKey (flip replicatePositiveNat) (getCounts ys))
+    )
+  ≡⟨ prop-Bag-fold-<> _ _ ⟩
+    mfromCounts xs <> mfromCounts ys
+  ∎
+
+-- | 'mfromCounts' is a left-inverse of 'mtoCounts'.
+prop-mfromCounts-mtoCounts
+  : ∀ ⦃ _ : Ord a ⦄ ⦃ _ : IsLawfulEq a ⦄ (xs : Bag a)
+  → mfromCounts (mtoCounts xs) ≡ xs
+--
+prop-mfromCounts-mtoCounts =
+    prop-Bag-equality lhs rhs
+      (Monoid.prop-morphism-∘ _ _ prop-morphism-mtoCounts prop-morphism-mfromCounts)
+      (Monoid.prop-morphism-id)
+      eq-singleton
+  where 
+    lhs = λ xs → mfromCounts (mtoCounts xs)
+    rhs = λ xs → xs
+
+    eq-singleton
+      : ∀ x → lhs (Bag.singleton x) ≡ rhs (Bag.singleton x)
+    eq-singleton x
+      rewrite prop-replicatePositiveNat-one x
+      = begin
+        (foldMap id $ Map.mapWithKey (flip replicatePositiveNat) $ Map.singleton x one)
+      ≡⟨ cong (foldMap id) (Map.prop-mapWithKey-singleton (flip replicatePositiveNat) _ _) ⟩
+        (foldMap id $ Map.singleton x (replicatePositiveNat one x))
+      ≡⟨ cong (λ o → foldMap id (Map.singleton x o)) (prop-replicatePositiveNat-one _) ⟩
+        foldMap id (Map.singleton x (Bag.singleton x))
+      ≡⟨ Map.prop-fold-singleton _ _ ⟩
+        Bag.singleton x
+      ∎

--- a/lib/bags/agda/Data/Map/Prop/Extra.agda
+++ b/lib/bags/agda/Data/Map/Prop/Extra.agda
@@ -10,6 +10,7 @@ import Data.Monoid.Refinement as Monoid
 
 open import Haskell.Law.Eq
 open import Haskell.Law.Equality
+open import Haskell.Law.Monoid
 
 ------------------------------------------------------------------------------
 -- Move out: Properties of if_then_else
@@ -76,6 +77,22 @@ module _ {k : Type} ⦃ _ : Ord k ⦄ where
   postulate
    prop-toAscList-empty
     : toAscList (empty {k} {a}) ≡ []
+
+{-----------------------------------------------------------------------------
+    Proofs
+    foldMap id
+------------------------------------------------------------------------------}
+module _ {k : Type} ⦃ _ : Ord k ⦄ where
+
+  --
+  prop-fold-singleton
+    : ∀ ⦃ _ : Monoid a ⦄ ⦃ _ : IsLawfulMonoid a ⦄ (key : k) (x : a)
+    → let fold = foldMap id
+      in  fold (singleton key x) ≡ x
+  --
+  prop-fold-singleton key x
+    rewrite prop-toAscList-singleton key x
+    = rightIdentity _
 
 {-----------------------------------------------------------------------------
     Proofs

--- a/lib/bags/agda/Data/Map/Prop/Extra.agda
+++ b/lib/bags/agda/Data/Map/Prop/Extra.agda
@@ -286,6 +286,27 @@ module _ {k : Type} ⦃ _ : Ord k ⦄ where
 ------------------------------------------------------------------------------}
 module _ {k : Type} ⦃ _ : Ord k ⦄ where
 
+  -- | 'mapWithKey' on a singleton maps the element of the singleton.
+  prop-mapWithKey-singleton
+    : ∀ ⦃ _ : IsLawfulEq k ⦄ (f : k → a → b) (key : k) (x : a)
+    → mapWithKey f (singleton key x) ≡ singleton key (f key x) 
+  --
+  prop-mapWithKey-singleton {a = a} {b = b} f key x = prop-equality lemma
+    where
+      lemma
+        : ∀ (key2 : k)
+        → lookup key2 (mapWithKey f (singleton key x))
+          ≡ lookup key2 (singleton key (f key x))
+      lemma key2
+        rewrite prop-lookup-mapWithKey key2 (singleton key x) f
+        rewrite prop-lookup-insert {a = a} key2 key x empty
+        rewrite prop-lookup-empty {a = a} key2
+        rewrite prop-lookup-insert {a = b} key2 key (f key x) empty
+        rewrite prop-lookup-empty {a = b} key2
+        with key2 == key in eq
+      ... | False = refl
+      ... | True  rewrite equality key2 key eq = refl
+
   -- | 'mapWithKey' an an empty map gives the empty map.
   prop-mapWithKey-empty
     : ∀ (f : k → a → b)

--- a/lib/bags/agda/Data/Map/Prop/Extra.agda
+++ b/lib/bags/agda/Data/Map/Prop/Extra.agda
@@ -286,6 +286,21 @@ module _ {k : Type} ⦃ _ : Ord k ⦄ where
 ------------------------------------------------------------------------------}
 module _ {k : Type} ⦃ _ : Ord k ⦄ where
 
+  -- | 'mapWithKey' an an empty map gives the empty map.
+  prop-mapWithKey-empty
+    : ∀ (f : k → a → b)
+    → mapWithKey f empty ≡ empty
+  --
+  prop-mapWithKey-empty {a = a} {b = b} f = prop-equality lemma
+    where
+      lemma
+        : ∀ (key : k) → lookup key (mapWithKey f empty) ≡ lookup key empty
+      lemma key
+        rewrite prop-lookup-mapWithKey key empty f
+        rewrite prop-lookup-empty {a = a} key
+        rewrite prop-lookup-empty {a = b} key
+        = refl
+
   -- | 'mapWithKey' distributes over 'unionWith' if the
   -- involved functions distribue over each other.
   prop-mapWithKey-unionWith

--- a/lib/bags/agda/Data/Map/Prop/Extra.agda
+++ b/lib/bags/agda/Data/Map/Prop/Extra.agda
@@ -279,3 +279,36 @@ module _ {k : Type} ⦃ _ : Ord k ⦄ where
       ... | Just x  | Nothing | Just z  = refl 
       ... | Just x  | Just y  | Nothing = refl 
       ... | Just x  | Just y  | Just z  = cong Just (cond x y z) 
+
+{-----------------------------------------------------------------------------
+    Proofs
+    mapWithKey
+------------------------------------------------------------------------------}
+module _ {k : Type} ⦃ _ : Ord k ⦄ where
+
+  -- | 'mapWithKey' distributes over 'unionWith' if the
+  -- involved functions distribue over each other.
+  prop-mapWithKey-unionWith
+    : ∀ (f : k → a → b) (g : a → a → a) (xs ys : Map k a)
+        (g' : b → b → b)
+    → (∀ key x y → f key (g x y) ≡ g' (f key x) (f key y))
+    → mapWithKey f (unionWith g xs ys)
+      ≡ unionWith g' (mapWithKey f xs) (mapWithKey f ys)
+  --
+  prop-mapWithKey-unionWith f g xs ys g' cond = prop-equality lemma
+    where
+      lemma
+        : ∀ (key : k)
+        → lookup key (mapWithKey f (unionWith g xs ys))
+          ≡ lookup key (unionWith g' (mapWithKey f xs) (mapWithKey f ys))
+      lemma key
+        rewrite prop-lookup-mapWithKey key (unionWith g xs ys) f
+        rewrite prop-lookup-unionWith key g xs ys
+        rewrite prop-lookup-unionWith key g' (mapWithKey f xs) (mapWithKey f ys)
+        rewrite prop-lookup-mapWithKey key xs f
+        rewrite prop-lookup-mapWithKey key ys f
+        with lookup key xs | lookup key ys
+      ... | Nothing | Nothing = refl
+      ... | Nothing | Just y  = refl
+      ... | Just x  | Nothing = refl
+      ... | Just x  | Just y  = cong Just (cond key x y)

--- a/lib/bags/agda/bags.agda
+++ b/lib/bags/agda/bags.agda
@@ -14,6 +14,7 @@ import Data.Monoid.Refinement
 import Data.Bag
 import Data.Bag.Counts
 import Data.Bag.Raw
+import Data.Bag.Prop.Conversion
 import Data.Bag.Prop.Deletion
 
 import Data.Table.Def

--- a/lib/bags/bags.cabal
+++ b/lib/bags/bags.cabal
@@ -68,6 +68,7 @@ library
 
   exposed-modules:
     Data.Bag
+    Data.Bag.Prop.Conversion
     Data.Bag.Prop.Core
     Data.Bag.Prop.Deletion
     Data.Bag.Prop.Operations

--- a/lib/bags/haskell/Data/Bag/Counts.hs
+++ b/lib/bags/haskell/Data/Bag/Counts.hs
@@ -35,6 +35,13 @@ instance Semigroup PositiveNat where
     OnePlus x <> OnePlus y = OnePlus (x + y + 1)
 
 {-|
+Construct a 'Bag' by replicating one item multiple times.
+-}
+replicatePositiveNat :: PositiveNat -> a -> Bag a
+replicatePositiveNat n x
+  = mconcat $ replicateNat (natFromPositiveNat n) (Bag.singleton x)
+
+{-|
 'Counts' is a different representation for 'Bag',
 where items are mapped to their number of occurrences.
 
@@ -56,15 +63,15 @@ instance (Ord a) => Monoid (Counts a) where
 instance (Ord a) => Data.Monoid.Refinement.Commutative (Counts a)
          where
 
-toCounts' :: Ord a => Bag a -> Counts a
-toCounts' = foldBag singleton
+mtoCounts :: Ord a => Bag a -> Counts a
+mtoCounts = foldBag singleton
 
 {-|
 Convert a 'Bag' to a mapping from items to their number of occurrences.
 -}
 toCounts :: Ord a => Bag a -> Map a Natural
 toCounts
-  = fmap natFromPositiveNat . (\ r -> getCounts r) . toCounts'
+  = fmap natFromPositiveNat . (\ r -> getCounts r) . mtoCounts
 
 replicateBag :: Natural -> a -> Bag a
 replicateBag n x = mconcat $ replicateNat n (Bag.singleton x)
@@ -74,6 +81,11 @@ Convert a map of items and their number of occurrences to a 'Bag'.
 -}
 fromCounts :: Ord a => Map a Natural -> Bag a
 fromCounts = foldMap id . Map.mapWithKey (flip replicateBag)
+
+mfromCounts :: Ord a => Counts a -> Bag a
+mfromCounts
+  = foldMap id .
+      Map.mapWithKey (flip replicatePositiveNat) . \ r -> getCounts r
 
 -- * Properties
 {- $prop-Counts-<>-assoc

--- a/lib/bags/haskell/Data/Bag/Prop/Conversion.hs
+++ b/lib/bags/haskell/Data/Bag/Prop/Conversion.hs
@@ -1,0 +1,69 @@
+{-# OPTIONS_GHC -Wno-unused-top-binds #-}
+
+module Data.Bag.Prop.Conversion 
+    (
+    -- * Conversion
+    -- $prop-morphism-mtoCounts
+    
+    -- $prop-morphism-mfromCounts
+    
+    -- $prop-mfromCounts-mtoCounts
+    
+    )
+    where
+
+import Prelude hiding (null, filter, lookup, map, concatMap, replicate)
+
+dummyPropConversion :: ()
+dummyPropConversion = ()
+
+-- * Properties
+{- $prop-Bag-fold-<>
+#p:prop-Bag-fold-<>#
+
+[prop-Bag-fold-<>]:
+    @'foldMap' 'id'@ commutes with 'Bag'.
+    
+    > prop-Bag-fold-<>
+    >   : ∀ {k} ⦃ _ : Ord k ⦄ (xs ys : Map k (Bag a))
+    >   → foldMap id (Map.unionWith (_<>_) xs ys)
+    >     ≡ foldMap id xs <> foldMap id ys
+-}
+{- $prop-Bag-fold-mempty
+#p:prop-Bag-fold-mempty#
+
+[prop-Bag-fold-mempty]:
+    @'foldMap' 'id'@ on an empty 'Map' gives the empty 'Bag'.
+    
+    > prop-Bag-fold-mempty
+    >   : ∀ {k} ⦃ _ : Ord k ⦄
+    >   → foldMap id (Map.empty {k}) ≡ mempty {Bag a}
+-}
+{- $prop-mfromCounts-mtoCounts
+#p:prop-mfromCounts-mtoCounts#
+
+[prop-mfromCounts-mtoCounts]:
+    'mfromCounts' is a left-inverse of 'mtoCounts'.
+    
+    > prop-mfromCounts-mtoCounts
+    >   : ∀ ⦃ _ : Ord a ⦄ ⦃ _ : IsLawfulEq a ⦄ (xs : Bag a)
+    >   → mfromCounts (mtoCounts xs) ≡ xs
+-}
+{- $prop-morphism-mfromCounts
+#p:prop-morphism-mfromCounts#
+
+[prop-morphism-mfromCounts]:
+    'Data.Bag.Counts.mfromCounts' is a monoid homomorphism.
+    
+    > prop-morphism-mfromCounts
+    >   : ⦃ _ : Ord a ⦄ → Monoid.IsHomomorphism (mfromCounts {a})
+-}
+{- $prop-morphism-mtoCounts
+#p:prop-morphism-mtoCounts#
+
+[prop-morphism-mtoCounts]:
+    'Data.Bag.Counts.mtoCounts' is a monoid homomorphism.
+    
+    > prop-morphism-mtoCounts
+    >   : ⦃ _ : Ord a ⦄ → Monoid.IsHomomorphism (mtoCounts {a})
+-}


### PR DESCRIPTION
This pull request adds proofs about the conversion from `Bag` to the `Counts` data structure and vice versa.