### PR TITLE
Add `Data.Bag.fromUnique`

### DIFF
--- a/lib/bags/agda/Data/Bag.agda
+++ b/lib/bags/agda/Data/Bag.agda
@@ -45,6 +45,7 @@ module Data.Bag
 
   -- * Properties
   ; module Data.Bag.Prop.Core
+  ; module Data.Bag.Prop.Conversion
   ; module Data.Bag.Prop.Deletion
   ; module Data.Bag.Prop.Operations
   -} where
@@ -55,6 +56,7 @@ module Data.Bag
   import Data.Bag.Quotient
   import Data.Bag.Found (deleteOne)
   import Data.Bag.Prop.Core
+  import Data.Bag.Prop.Conversion
   import Data.Bag.Prop.Deletion
   import Data.Bag.Prop.Operations
 #-}

--- a/lib/bags/agda/Data/Bag.agda
+++ b/lib/bags/agda/Data/Bag.agda
@@ -41,6 +41,7 @@ module Data.Bag
   -- ** Conversion
   ; toCounts
   ; fromCounts
+  ; fromUnique
 
   -- * Properties
   ; module Data.Bag.Prop.Core
@@ -64,7 +65,7 @@ open import Haskell.Data.Bag.Quotient   public hiding
   ; prop-foldBag-unique
   )
 open import Data.Bag.Def                public
-open import Data.Bag.Counts             using (toCounts; fromCounts)
+open import Data.Bag.Counts             using (toCounts; fromCounts; fromUnique)
 open import Data.Bag.Found              public using (deleteOne)
 import      Data.Bag.Prop.Core
 open import Data.Bag.Prop.Core          public hiding
@@ -82,7 +83,7 @@ import Data.Monoid.Refinement as Monoid
 import Data.Monoid.Morphism as Monoid
 
 {-# FOREIGN AGDA2HS
-  import Data.Bag.Counts (toCounts, fromCounts)
+  import Data.Bag.Counts (toCounts, fromCounts, fromUnique)
 #-}
 
 {-----------------------------------------------------------------------------

--- a/lib/bags/agda/Data/Bag/Counts.agda
+++ b/lib/bags/agda/Data/Bag/Counts.agda
@@ -13,6 +13,7 @@ module Data.Bag.Counts
   ; natFromPositiveNat
   ; toCounts
   ; fromCounts
+  ; fromUnique
   -} where
 
 open import Haskell.Prelude hiding (lookup; null)
@@ -301,3 +302,13 @@ instance
   iEqBag ._==_ xs ys = mtoCounts xs == mtoCounts ys
 
 {-# COMPILE AGDA2HS iEqBag #-}
+
+-- | Given a 'Bag' that contains only one unique item
+-- (though perhaps multiple times), extract that item.
+fromUnique : ⦃ Ord a ⦄ → Bag a → Maybe a
+fromUnique xs =
+  case Map.toAscList (toCounts xs) of λ where
+    ((x , _) ∷ []) → Just x
+    _              → Nothing
+
+{-# COMPILE AGDA2HS fromUnique #-}

--- a/lib/bags/haskell/Data/Bag.hs
+++ b/lib/bags/haskell/Data/Bag.hs
@@ -43,6 +43,7 @@ module Data.Bag
     fromUnique,
     -- * Properties
     module Data.Bag.Prop.Core,
+    module Data.Bag.Prop.Conversion,
     module Data.Bag.Prop.Deletion,
     module Data.Bag.Prop.Operations,
     )
@@ -55,6 +56,7 @@ import Data.Bag.Def
 import Data.Bag.Quotient
 import Data.Bag.Found (deleteOne)
 import Data.Bag.Prop.Core
+import Data.Bag.Prop.Conversion
 import Data.Bag.Prop.Deletion
 import Data.Bag.Prop.Operations
 

--- a/lib/bags/haskell/Data/Bag.hs
+++ b/lib/bags/haskell/Data/Bag.hs
@@ -40,6 +40,7 @@ module Data.Bag
     -- ** Conversion
     toCounts,
     fromCounts,
+    fromUnique,
     -- * Properties
     module Data.Bag.Prop.Core,
     module Data.Bag.Prop.Deletion,
@@ -57,7 +58,7 @@ import Data.Bag.Prop.Core
 import Data.Bag.Prop.Deletion
 import Data.Bag.Prop.Operations
 
-import Data.Bag.Counts (toCounts, fromCounts)
+import Data.Bag.Counts (toCounts, fromCounts, fromUnique)
 
 -- * Properties
 {- $prop-foldBag-singleton

--- a/lib/bags/haskell/Data/Bag/Counts.hs
+++ b/lib/bags/haskell/Data/Bag/Counts.hs
@@ -11,6 +11,7 @@ module Data.Bag.Counts
     natFromPositiveNat,
     toCounts,
     fromCounts,
+    fromUnique,
     )
     where
 
@@ -19,7 +20,7 @@ import Data.Bag.Quotient (Bag, foldBag)
 import qualified Data.Bag.Quotient as Bag (singleton)
 import Data.List.Extra (replicateNat)
 import Data.Map (Map)
-import qualified Data.Map as Map (empty, mapWithKey, singleton, unionWith)
+import qualified Data.Map as Map (empty, mapWithKey, singleton, toAscList, unionWith)
 import qualified Data.Monoid.Refinement (Commutative)
 import Numeric.Natural (Natural)
 
@@ -96,6 +97,16 @@ mfromCounts
 
 instance (Ord a) => Eq (Bag a) where
     xs == ys = mtoCounts xs == mtoCounts ys
+
+{-|
+Given a 'Bag' that contains only one unique item
+(though perhaps multiple times), extract that item.
+-}
+fromUnique :: Ord a => Bag a -> Maybe a
+fromUnique xs
+  = case Map.toAscList (toCounts xs) of
+        [(x, _)] -> Just x
+        _ -> Nothing
 
 -- * Properties
 {- $prop-Counts-<>-assoc


### PR DESCRIPTION
This pull request adds a function `fromUnique` that allows extraction of an element from `Bag a` in the event that the `Bag` consists of multiple copies of that single element.

In general, it is not trivial to extract an element from a `Bag`, because the order of elements does not matter, and there is no canonical choice. However, elements can be extracted using `toCounts` which requires an `Ord` instance for items.